### PR TITLE
making error displays in dialog reusable

### DIFF
--- a/clients/core/src/Application/ApplicationConfiguration/components/ApplicationConfigDialog.tsx
+++ b/clients/core/src/Application/ApplicationConfiguration/components/ApplicationConfigDialog.tsx
@@ -16,7 +16,8 @@ import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { UpdateCoursePhase } from '@/interfaces/course_phase'
 import { updateCoursePhase } from '../../../network/mutations/updateCoursePhase'
 import { useParams } from 'react-router-dom'
-import { AlertCircle, Loader2 } from 'lucide-react'
+import { DialogLoadingDisplay } from '@/components/dialog/DialogLoadingDisplay'
+import { DialogErrorDisplay } from '@/components/dialog/DialogErrorDisplay'
 
 interface ApplicationConfigDialogProps {
   isOpen: boolean
@@ -71,20 +72,9 @@ export function ApplicationConfigDialog({
     <Dialog open={isOpen} onOpenChange={onClose}>
       <DialogContent>
         {isPending ? (
-          <div className='flex flex-col items-center justify-center h-48'>
-            <Loader2 className='h-10 w-10 text-primary animate-spin' />
-            <p className='mt-4 text-lg font-medium text-muted-foreground'>
-              Saving application config...
-            </p>
-          </div>
+          <DialogLoadingDisplay customMessage='Saving application config...' />
         ) : isMutateError ? (
-          <div className='flex flex-col items-center justify-center h-48'>
-            <AlertCircle className='h-10 w-10 text-destructive' />
-            <p className='mt-4 text-lg font-medium text-destructive'>Error: {error.message}</p>
-            <p className='mt-2 text-sm text-muted-foreground'>
-              Please try again or contact support if the problem persists.
-            </p>
-          </div>
+          <DialogErrorDisplay error={error} />
         ) : (
           <>
             <DialogHeader>

--- a/clients/core/src/Course/AddingCourse/AddCourseDialog.tsx
+++ b/clients/core/src/Course/AddingCourse/AddCourseDialog.tsx
@@ -14,8 +14,9 @@ import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { PostCourse } from '@/interfaces/post_course'
 import { postNewCourse } from '../../network/mutations/postNewCourse'
 import { useNavigate } from 'react-router-dom'
-import { AlertCircle, Loader2 } from 'lucide-react'
 import { useKeycloak } from '@/keycloak/useKeycloak'
+import { DialogLoadingDisplay } from '@/components/dialog/DialogLoadingDisplay'
+import { DialogErrorDisplay } from '@/components/dialog/DialogErrorDisplay'
 
 interface AddCourseDialogProps {
   children: React.ReactNode
@@ -112,18 +113,9 @@ export const AddCourseDialog: React.FC<AddCourseDialogProps> = ({ children }) =>
       <DialogTrigger asChild>{children}</DialogTrigger>
       <DialogContent className='sm:max-w-[550px]'>
         {isPending ? (
-          <div className='flex flex-col items-center justify-center h-48'>
-            <Loader2 className='h-10 w-10 text-primary animate-spin' />
-            <p className='mt-4 text-lg font-medium text-muted-foreground'>Loading course data...</p>
-          </div>
+          <DialogLoadingDisplay customMessage='Updating course data...' />
         ) : isError ? (
-          <div className='flex flex-col items-center justify-center h-48'>
-            <AlertCircle className='h-10 w-10 text-destructive' />
-            <p className='mt-4 text-lg font-medium text-destructive'>Error: {error.message}</p>
-            <p className='mt-2 text-sm text-muted-foreground'>
-              Please try again or contact support if the problem persists.
-            </p>
-          </div>
+          <DialogErrorDisplay error={error} />
         ) : (
           <>
             <DialogHeader>

--- a/clients/shared_library/components/dialog/DialogErrorDisplay.tsx
+++ b/clients/shared_library/components/dialog/DialogErrorDisplay.tsx
@@ -1,0 +1,21 @@
+import { AlertCircle } from 'lucide-react'
+
+interface DialogErrorDisplayProps {
+  customMessage?: string
+  error: Error
+}
+
+export const DialogErrorDisplay = ({
+  customMessage,
+  error,
+}: DialogErrorDisplayProps): JSX.Element => {
+  return (
+    <div className='flex flex-col items-center justify-center h-48'>
+      <AlertCircle className='h-10 w-10 text-destructive' />
+      <p className='mt-4 text-lg font-medium text-destructive'>Error: {error.message}</p>
+      <p className='mt-2 text-sm text-muted-foreground'>
+        {customMessage ?? 'Please try again or contact the administrators if the problem persists.'}
+      </p>
+    </div>
+  )
+}

--- a/clients/shared_library/components/dialog/DialogLoadingDisplay.tsx
+++ b/clients/shared_library/components/dialog/DialogLoadingDisplay.tsx
@@ -1,0 +1,16 @@
+import { Loader2 } from 'lucide-react'
+
+interface DialogLoadingDisplayProps {
+  customMessage?: string
+}
+
+export const DialogLoadingDisplay = ({ customMessage }: DialogLoadingDisplayProps): JSX.Element => {
+  return (
+    <div className='flex flex-col items-center justify-center h-48'>
+      <Loader2 className='h-10 w-10 text-primary animate-spin' />
+      <p className='mt-4 text-lg font-medium text-muted-foreground'>
+        {customMessage ?? 'Loading...'}
+      </p>
+    </div>
+  )
+}


### PR DESCRIPTION
This pull request introduces reusable components for displaying loading and error states in dialogs, and integrates these components into existing dialogs in the application. The main changes include the creation of `DialogLoadingDisplay` and `DialogErrorDisplay` components and their usage in `ApplicationConfigDialog` and `AddCourseDialog`.

Reusable components:

* [`clients/shared_library/components/dialog/DialogErrorDisplay.tsx`](diffhunk://#diff-8e2d2a0b616af7e977739955490542fbdc64ccd7b959c2a4cb429546c5cce92eR1-R21): Added a new component `DialogErrorDisplay` to display error messages in a consistent format.
* [`clients/shared_library/components/dialog/DialogLoadingDisplay.tsx`](diffhunk://#diff-ab8526c84c82efa75d0f530df5ea94345b946dd85365f10e2b8a46adc4a8e791R1-R16): Added a new component `DialogLoadingDisplay` to display loading indicators in a consistent format.

Integration into existing dialogs:

* [`clients/core/src/Application/ApplicationConfiguration/components/ApplicationConfigDialog.tsx`](diffhunk://#diff-f1fb90d13964b9a4c62886a6945f590337caae87d2602c74ad99bfa0dcc8d2a1L19-R20): Replaced inline loading and error display code with `DialogLoadingDisplay` and `DialogErrorDisplay` components. [[1]](diffhunk://#diff-f1fb90d13964b9a4c62886a6945f590337caae87d2602c74ad99bfa0dcc8d2a1L19-R20) [[2]](diffhunk://#diff-f1fb90d13964b9a4c62886a6945f590337caae87d2602c74ad99bfa0dcc8d2a1L74-R77)
* [`clients/core/src/Course/AddingCourse/AddCourseDialog.tsx`](diffhunk://#diff-3574c14bb783de693d993f157cb9142ac52c87e4f8151f0738bfd38bc344bc24L17-R19): Replaced inline loading and error display code with `DialogLoadingDisplay` and `DialogErrorDisplay` components. [[1]](diffhunk://#diff-3574c14bb783de693d993f157cb9142ac52c87e4f8151f0738bfd38bc344bc24L17-R19) [[2]](diffhunk://#diff-3574c14bb783de693d993f157cb9142ac52c87e4f8151f0738bfd38bc344bc24L115-R118)