### PR TITLE
Migrating passed to pass status

### DIFF
--- a/server/coursePhase/coursePhaseParticipation/coursePhaseParticipationDTO/create_course_phase_participation.go
+++ b/server/coursePhase/coursePhaseParticipation/coursePhaseParticipationDTO/create_course_phase_participation.go
@@ -2,17 +2,16 @@ package coursePhaseParticipationDTO
 
 import (
 	"github.com/google/uuid"
-	"github.com/jackc/pgx/v5/pgtype"
 	db "github.com/niclasheun/prompt2.0/db/sqlc"
 	"github.com/niclasheun/prompt2.0/meta"
 	log "github.com/sirupsen/logrus"
 )
 
 type CreateCoursePhaseParticipation struct {
-	CourseParticipationID uuid.UUID     `json:"course_participation_id"`
-	CoursePhaseID         uuid.UUID     `json:"course_phase_id"`
-	Passed                bool          `json:"passed"`
-	MetaData              meta.MetaData `json:"meta_data"`
+	CourseParticipationID uuid.UUID         `json:"course_participation_id"`
+	CoursePhaseID         uuid.UUID         `json:"course_phase_id"`
+	PassStatus            db.NullPassStatus `json:"pass_status"`
+	MetaData              meta.MetaData     `json:"meta_data"`
 }
 
 func (c CreateCoursePhaseParticipation) GetDBModel() (db.CreateCoursePhaseParticipationParams, error) {
@@ -25,7 +24,7 @@ func (c CreateCoursePhaseParticipation) GetDBModel() (db.CreateCoursePhasePartic
 	return db.CreateCoursePhaseParticipationParams{
 		CourseParticipationID: c.CourseParticipationID,
 		CoursePhaseID:         c.CoursePhaseID,
-		Passed:                pgtype.Bool{Bool: c.Passed, Valid: true},
+		PassStatus:            c.PassStatus,
 		MetaData:              metaDataBytes,
 	}, nil
 

--- a/server/coursePhase/coursePhaseParticipation/coursePhaseParticipationDTO/get_course_phase_participation.go
+++ b/server/coursePhase/coursePhaseParticipation/coursePhaseParticipationDTO/get_course_phase_participation.go
@@ -11,7 +11,7 @@ type GetCoursePhaseParticipation struct {
 	ID                    uuid.UUID     `json:"id"`
 	CourseParticipationID uuid.UUID     `json:"course_participation_id"`
 	CoursePhaseID         uuid.UUID     `json:"course_phase_id"`
-	Passed                bool          `json:"passed"`
+	PassStatus            string        `json:"passed_status"`
 	MetaData              meta.MetaData `json:"meta_data"`
 }
 
@@ -26,7 +26,7 @@ func GetCoursePhaseParticipationDTOFromDBModel(model db.CoursePhaseParticipation
 		ID:                    model.ID,
 		CourseParticipationID: model.CourseParticipationID,
 		CoursePhaseID:         model.CoursePhaseID,
-		Passed:                model.Passed.Bool,
+		PassStatus:            getPassStatusString(model.PassStatus),
 		MetaData:              metaData,
 	}, nil
 }

--- a/server/coursePhase/coursePhaseParticipation/coursePhaseParticipationDTO/pass_status.go
+++ b/server/coursePhase/coursePhaseParticipation/coursePhaseParticipationDTO/pass_status.go
@@ -1,0 +1,10 @@
+package coursePhaseParticipationDTO
+
+import db "github.com/niclasheun/prompt2.0/db/sqlc"
+
+func getPassStatusString(passStatus db.NullPassStatus) string {
+	if passStatus.Valid {
+		return string(passStatus.PassStatus)
+	}
+	return string(db.PassStatusNotAssessed)
+}

--- a/server/coursePhase/coursePhaseParticipation/coursePhaseParticipationDTO/update_course_phase_participation.go
+++ b/server/coursePhase/coursePhaseParticipation/coursePhaseParticipationDTO/update_course_phase_participation.go
@@ -2,16 +2,15 @@ package coursePhaseParticipationDTO
 
 import (
 	"github.com/google/uuid"
-	"github.com/jackc/pgx/v5/pgtype"
 	db "github.com/niclasheun/prompt2.0/db/sqlc"
 	"github.com/niclasheun/prompt2.0/meta"
 	log "github.com/sirupsen/logrus"
 )
 
 type UpdateCoursePhaseParticipation struct {
-	ID       uuid.UUID     `json:"id"`
-	Passed   pgtype.Bool   `json:"passed"`
-	MetaData meta.MetaData `json:"meta_data"`
+	ID         uuid.UUID         `json:"id"`
+	PassStatus db.NullPassStatus `json:"passed"`
+	MetaData   meta.MetaData     `json:"meta_data"`
 }
 
 func (c UpdateCoursePhaseParticipation) GetDBModel() (db.UpdateCoursePhaseParticipationParams, error) {
@@ -22,23 +21,9 @@ func (c UpdateCoursePhaseParticipation) GetDBModel() (db.UpdateCoursePhasePartic
 	}
 
 	return db.UpdateCoursePhaseParticipationParams{
-		ID:       c.ID,
-		Passed:   c.Passed,
-		MetaData: metaDataBytes,
+		ID:         c.ID,
+		PassStatus: c.PassStatus,
+		MetaData:   metaDataBytes,
 	}, nil
 
-}
-
-func UpdateCoursePhaseParticipationDTOFromDBModel(model db.CoursePhaseParticipation) (UpdateCoursePhaseParticipation, error) {
-	metaData, err := meta.GetMetaDataDTOFromDBModel(model.MetaData)
-	if err != nil {
-		log.Error("failed to create CoursePhaseParticipation DTO from DB model")
-		return UpdateCoursePhaseParticipation{}, err
-	}
-
-	return UpdateCoursePhaseParticipation{
-		ID:       model.ID,
-		Passed:   model.Passed,
-		MetaData: metaData,
-	}, nil
 }

--- a/server/coursePhase/coursePhaseParticipation/router.go
+++ b/server/coursePhase/coursePhaseParticipation/router.go
@@ -77,12 +77,12 @@ func updateCoursePhaseParticipation(c *gin.Context) {
 
 	updatedCourseParticipation.ID = id
 
-	courseParticipation, err := UpdateCoursePhaseParticipation(c, updatedCourseParticipation)
+	err = UpdateCoursePhaseParticipation(c, updatedCourseParticipation)
 	if err != nil {
 		handleError(c, http.StatusInternalServerError, err)
 		return
 	}
-	c.IndentedJSON(http.StatusOK, courseParticipation)
+	c.JSON(http.StatusOK, gin.H{"message": "updated course phase participation"})
 }
 
 func handleError(c *gin.Context, statusCode int, err error) {

--- a/server/coursePhase/coursePhaseParticipation/router.go
+++ b/server/coursePhase/coursePhaseParticipation/router.go
@@ -6,13 +6,13 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 	"github.com/niclasheun/prompt2.0/coursePhase/coursePhaseParticipation/coursePhaseParticipationDTO"
-	"github.com/sirupsen/logrus"
 )
 
 func setupCoursePhaseParticipationRouter(routerGroup *gin.RouterGroup) {
 	courseParticipation := routerGroup.Group("/course_phases/:uuid/participations")
 	courseParticipation.GET("", getParticipationsForCoursePhase)
 	courseParticipation.POST("", createCoursePhaseParticipation)
+	courseParticipation.GET("/:participation_uuid", getParticipation)
 	courseParticipation.PUT("/:participation_uuid", updateCoursePhaseParticipation)
 }
 
@@ -30,6 +30,22 @@ func getParticipationsForCoursePhase(c *gin.Context) {
 	}
 
 	c.IndentedJSON(http.StatusOK, courseParticipations)
+}
+
+func getParticipation(c *gin.Context) {
+	id, err := uuid.Parse(c.Param("participation_uuid"))
+	if err != nil {
+		handleError(c, http.StatusBadRequest, err)
+		return
+	}
+
+	courseParticipation, err := GetCoursePhaseParticipation(c, id)
+	if err != nil {
+		handleError(c, http.StatusInternalServerError, err)
+		return
+	}
+
+	c.IndentedJSON(http.StatusOK, courseParticipation)
 }
 
 func createCoursePhaseParticipation(c *gin.Context) {
@@ -72,8 +88,6 @@ func updateCoursePhaseParticipation(c *gin.Context) {
 		handleError(c, http.StatusBadRequest, err)
 		return
 	}
-
-	logrus.Error(id)
 
 	updatedCourseParticipation.ID = id
 

--- a/server/coursePhase/coursePhaseParticipation/router_test.go
+++ b/server/coursePhase/coursePhaseParticipation/router_test.go
@@ -11,8 +11,8 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
-	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/niclasheun/prompt2.0/coursePhase/coursePhaseParticipation/coursePhaseParticipationDTO"
+	db "github.com/niclasheun/prompt2.0/db/sqlc"
 	"github.com/niclasheun/prompt2.0/meta"
 	"github.com/niclasheun/prompt2.0/testutils"
 	"github.com/stretchr/testify/assert"
@@ -78,7 +78,7 @@ func (suite *RouterTestSuite) TestCreateCoursePhaseParticipation() {
 
 	newParticipation := coursePhaseParticipationDTO.CreateCoursePhaseParticipation{
 		CourseParticipationID: uuid.MustParse("65dcc535-a9ab-4421-a2bc-0f09780ca59e"),
-		Passed:                false,
+		PassStatus:            db.NullPassStatus{PassStatus: "failed", Valid: true},
 		MetaData:              metaData,
 	}
 	body, _ := json.Marshal(newParticipation)
@@ -103,26 +103,38 @@ func (suite *RouterTestSuite) TestUpdateCoursePhaseParticipation() {
 	assert.NoError(suite.T(), err)
 
 	updatedParticipation := coursePhaseParticipationDTO.UpdateCoursePhaseParticipation{
-		ID:       uuid.MustParse("7698f081-df55-4136-a58c-1a166bb1bbda"),
-		MetaData: metaData,
-		Passed:   pgtype.Bool{Bool: true, Valid: true},
+		ID:         uuid.MustParse("7698f081-df55-4136-a58c-1a166bb1bbda"),
+		MetaData:   metaData,
+		PassStatus: db.NullPassStatus{PassStatus: "passed", Valid: true},
 	}
 	body, _ := json.Marshal(updatedParticipation)
 
+	// Send the update request
 	req := httptest.NewRequest(http.MethodPut, "/api/course_phases/3d1f3b00-87f3-433b-a713-178c4050411b/participations/7698f081-df55-4136-a58c-1a166bb1bbda", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
 
 	suite.router.ServeHTTP(w, req)
 
+	// Assert the update request was successful
 	assert.Equal(suite.T(), http.StatusOK, w.Code)
-	var updated coursePhaseParticipationDTO.UpdateCoursePhaseParticipation
-	err = json.Unmarshal(w.Body.Bytes(), &updated)
+
+	// Perform a GET request to verify the changes
+	getReq := httptest.NewRequest(http.MethodGet, "/api/course_phases/3d1f3b00-87f3-433b-a713-178c4050411b/participations/7698f081-df55-4136-a58c-1a166bb1bbda", nil)
+	getW := httptest.NewRecorder()
+
+	suite.router.ServeHTTP(getW, getReq)
+
+	// Assert the GET request was successful
+	assert.Equal(suite.T(), http.StatusOK, getW.Code)
+
+	// Verify the returned data matches the expected updated data
+	var updated coursePhaseParticipationDTO.GetCoursePhaseParticipation
+	err = json.Unmarshal(getW.Body.Bytes(), &updated)
 	assert.NoError(suite.T(), err)
-	assert.Equal(suite.T(), updatedParticipation.ID, updated.ID)
-	assert.Equal(suite.T(), updatedParticipation.Passed, updated.Passed)
-	assert.Equal(suite.T(), "some skills", updated.MetaData["other-value"])
-	assert.Equal(suite.T(), "none", updated.MetaData["skills"])
+	assert.Equal(suite.T(), updatedParticipation.ID, updated.ID, "Participation ID should match")
+	assert.Equal(suite.T(), "passed", updated.PassStatus, "PassStatus should match")
+	assert.Equal(suite.T(), updatedParticipation.MetaData["other-value"], updated.MetaData["other-value"], "New Meta data should match")
 }
 
 func TestRouterTestSuite(t *testing.T) {

--- a/server/coursePhase/coursePhaseParticipation/service.go
+++ b/server/coursePhase/coursePhaseParticipation/service.go
@@ -61,6 +61,13 @@ func CreateCoursePhaseParticipation(ctx context.Context, newCoursePhaseParticipa
 
 	participation.ID = uuid.New()
 
+	if !participation.PassStatus.Valid {
+		participation.PassStatus = db.NullPassStatus{
+			Valid:      true,
+			PassStatus: "not_assessed",
+		}
+	}
+
 	createdParticipation, err := CoursePhaseParticipationServiceSingleton.queries.CreateCoursePhaseParticipation(ctx, participation)
 	if err != nil {
 		return coursePhaseParticipationDTO.GetCoursePhaseParticipation{}, err

--- a/server/coursePhase/coursePhaseParticipation/service_test.go
+++ b/server/coursePhase/coursePhaseParticipation/service_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
-	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/niclasheun/prompt2.0/coursePhase/coursePhaseParticipation/coursePhaseParticipationDTO"
+	db "github.com/niclasheun/prompt2.0/db/sqlc"
 	"github.com/niclasheun/prompt2.0/meta"
 	"github.com/niclasheun/prompt2.0/testutils"
 	log "github.com/sirupsen/logrus"
@@ -53,7 +53,6 @@ func (suite *CoursePhaseParticipationTestSuite) TestGetAllParticipationsForCours
 
 func (suite *CoursePhaseParticipationTestSuite) TestCreateCoursePhaseParticipation() {
 	jsonData := `{"a": "b"}`
-	// MetaData initialisieren
 	var metaData meta.MetaData
 	err := json.Unmarshal([]byte(jsonData), &metaData)
 	assert.NoError(suite.T(), err)
@@ -61,7 +60,7 @@ func (suite *CoursePhaseParticipationTestSuite) TestCreateCoursePhaseParticipati
 	newParticipation := coursePhaseParticipationDTO.CreateCoursePhaseParticipation{
 		CoursePhaseID:         uuid.MustParse("3d1f3b00-87f3-433b-a713-178c4050411b"),
 		CourseParticipationID: uuid.MustParse("65dcc535-a9ab-4421-a2bc-0f09780ca59e"),
-		Passed:                false,
+		PassStatus:            db.NullPassStatus{PassStatus: "passed", Valid: true},
 		MetaData:              metaData,
 	}
 
@@ -69,50 +68,53 @@ func (suite *CoursePhaseParticipationTestSuite) TestCreateCoursePhaseParticipati
 	assert.NoError(suite.T(), err)
 	assert.Equal(suite.T(), newParticipation.CoursePhaseID, createdParticipation.CoursePhaseID, "CoursePhaseID should match")
 	assert.Equal(suite.T(), newParticipation.MetaData, createdParticipation.MetaData, "Meta data should match")
+	assert.Equal(suite.T(), "passed", createdParticipation.PassStatus, "PassStatus should match")
 }
 
 func (suite *CoursePhaseParticipationTestSuite) TestUpdateCoursePhaseParticipation() {
-	// Replace with a valid participation ID from your dump
 	participationID := uuid.MustParse("7698f081-df55-4136-a58c-1a166bb1bbda")
 	jsonData := `{"other-value": "some skills"}`
-	// MetaData initialisieren
 	var metaData meta.MetaData
 	err := json.Unmarshal([]byte(jsonData), &metaData)
 	assert.NoError(suite.T(), err)
 
 	updatedParticipation := coursePhaseParticipationDTO.UpdateCoursePhaseParticipation{
-		ID:       participationID,
-		MetaData: metaData,
-		Passed:   pgtype.Bool{Bool: true, Valid: true},
+		ID:         participationID,
+		MetaData:   metaData,
+		PassStatus: db.NullPassStatus{PassStatus: "passed", Valid: true},
 	}
 
-	result, err := UpdateCoursePhaseParticipation(suite.ctx, updatedParticipation)
+	err = UpdateCoursePhaseParticipation(suite.ctx, updatedParticipation)
+	assert.NoError(suite.T(), err)
+	result, err := GetCoursePhaseParticipation(suite.ctx, participationID)
 	assert.NoError(suite.T(), err)
 	assert.Equal(suite.T(), updatedParticipation.ID, result.ID, "Participation ID should match")
-	assert.Equal(suite.T(), updatedParticipation.Passed, result.Passed, "Passed data should match")
+	assert.Equal(suite.T(), "passed", result.PassStatus, "PassStatus should match")
 	assert.Equal(suite.T(), updatedParticipation.MetaData["other-value"], result.MetaData["other-value"], "New Meta data should match")
-	assert.Equal(suite.T(), meta.MetaData{"skills": "none", "other-value": "some skills"}, result.MetaData, "Old Meta data should be unaffected - Meta data was not appended")
 }
 
 func (suite *CoursePhaseParticipationTestSuite) TestUpdateCoursePhaseParticipationWithMetaDataOverride() {
-	// Replace with a valid participation ID from your dump
 	participationID := uuid.MustParse("7698f081-df55-4136-a58c-1a166bb1bbda")
 	jsonData := `{"skills": "more than none", "other-value": "some skills"}`
-	// MetaData initialisieren
 	var metaData meta.MetaData
 	err := json.Unmarshal([]byte(jsonData), &metaData)
 	assert.NoError(suite.T(), err)
 
 	updatedParticipation := coursePhaseParticipationDTO.UpdateCoursePhaseParticipation{
-		ID:       participationID,
-		MetaData: metaData,
-		Passed:   pgtype.Bool{Bool: true, Valid: true},
+		ID:         participationID,
+		MetaData:   metaData,
+		PassStatus: db.NullPassStatus{Valid: false}, // Updated to use the ENUM value
 	}
 
-	result, err := UpdateCoursePhaseParticipation(suite.ctx, updatedParticipation)
+	BeforeResult, err := GetCoursePhaseParticipation(suite.ctx, participationID)
+	assert.NoError(suite.T(), err)
+
+	err = UpdateCoursePhaseParticipation(suite.ctx, updatedParticipation)
+	assert.NoError(suite.T(), err)
+	result, err := GetCoursePhaseParticipation(suite.ctx, participationID)
 	assert.NoError(suite.T(), err)
 	assert.Equal(suite.T(), updatedParticipation.ID, result.ID, "Participation ID should match")
-	assert.Equal(suite.T(), updatedParticipation.Passed, result.Passed, "Passed data should match")
+	assert.Equal(suite.T(), BeforeResult.PassStatus, result.PassStatus, "PassStatus should match")
 	assert.Equal(suite.T(), updatedParticipation.MetaData, result.MetaData, "New Meta data should match")
 }
 

--- a/server/database_dumps/application_administration.sql
+++ b/server/database_dumps/application_administration.sql
@@ -68,11 +68,13 @@ CREATE TABLE course_participation (
     student_id uuid NOT NULL
 );
 
+CREATE TYPE pass_status AS ENUM ('passed', 'failed', 'not_assessed');
+
 CREATE TABLE course_phase_participation (
     id uuid NOT NULL,
     course_participation_id uuid NOT NULL,
     course_phase_id uuid NOT NULL,
-    passed boolean,
+    pass_status pass_status,
     meta_data jsonb
 );
 

--- a/server/database_dumps/course_phase_participation_test.sql
+++ b/server/database_dumps/course_phase_participation_test.sql
@@ -21,6 +21,12 @@ SET default_tablespace = '';
 SET default_table_access_method = heap;
 
 --
+-- Name: pass_status; Type: TYPE; Schema: public; Owner: prompt-postgres
+--
+
+CREATE TYPE pass_status AS ENUM ('passed', 'failed', 'not_assessed');
+
+--
 -- Name: course_phase_participation; Type: TABLE; Schema: public; Owner: prompt-postgres
 --
 
@@ -28,26 +34,23 @@ CREATE TABLE course_phase_participation (
     id uuid NOT NULL,
     course_participation_id uuid NOT NULL,
     course_phase_id uuid NOT NULL,
-    passed boolean,
+    pass_status pass_status DEFAULT 'not_assessed',
     meta_data jsonb
 );
-
 
 --
 -- Data for Name: course_phase_participation; Type: TABLE DATA; Schema: public; Owner: prompt-postgres
 --
 
-INSERT INTO course_phase_participation (id, course_participation_id, course_phase_id, passed, meta_data)
+INSERT INTO course_phase_participation (id, course_participation_id, course_phase_id, pass_status, meta_data)
 VALUES 
-('7cd22e70-34b6-4416-8c1a-54f899a35951', '6e19bab2-53d0-4b6a-ac02-33b23988401a', '3d1f3b00-87f3-433b-a713-178c4050411b', false, '{}'),
-('71b5eff0-c3b7-4495-b37b-65fc211b4b69', '8713d7bc-1542-4366-88a9-1fa50945b052', '3d1f3b00-87f3-433b-a713-178c4050411b', false, '{}'),
-('ba42a9bb-2130-45f2-9522-65d23501ef7c', '0e762fdd-c4fa-49f4-9c38-c90160cc6caa', '3d1f3b00-87f3-433b-a713-178c4050411b', false, '{}'),
-('2c1d802c-f7c3-4ba0-b95f-f6a3edf91940', '0e762fdd-c4fa-49f4-9c38-c90160cc6caa', '500db7ed-2eb2-42d0-82b3-8750e12afa8a', false, '{}'),
-('ed30f4b3-73e9-4867-a148-7d0c9cdef451', '6e19bab2-53d0-4b6a-ac02-33b23988401a', '500db7ed-2eb2-42d0-82b3-8750e12afa8a', false, '{}'),
-('7698f081-df55-4136-a58c-1a166bb1bbda', '8713d7bc-1542-4366-88a9-1fa50945b052', '500db7ed-2eb2-42d0-82b3-8750e12afa8a', false, '{"skills": "none"}');
+('7cd22e70-34b6-4416-8c1a-54f899a35951', '6e19bab2-53d0-4b6a-ac02-33b23988401a', '3d1f3b00-87f3-433b-a713-178c4050411b', 'failed', '{}'),
+('71b5eff0-c3b7-4495-b37b-65fc211b4b69', '8713d7bc-1542-4366-88a9-1fa50945b052', '3d1f3b00-87f3-433b-a713-178c4050411b', 'failed', '{}'),
+('ba42a9bb-2130-45f2-9522-65d23501ef7c', '0e762fdd-c4fa-49f4-9c38-c90160cc6caa', '3d1f3b00-87f3-433b-a713-178c4050411b', 'failed', '{}'),
+('2c1d802c-f7c3-4ba0-b95f-f6a3edf91940', '0e762fdd-c4fa-49f4-9c38-c90160cc6caa', '500db7ed-2eb2-42d0-82b3-8750e12afa8a', 'failed', '{}'),
+('ed30f4b3-73e9-4867-a148-7d0c9cdef451', '6e19bab2-53d0-4b6a-ac02-33b23988401a', '500db7ed-2eb2-42d0-82b3-8750e12afa8a', 'failed', '{}'),
+('7698f081-df55-4136-a58c-1a166bb1bbda', '8713d7bc-1542-4366-88a9-1fa50945b052', '500db7ed-2eb2-42d0-82b3-8750e12afa8a', 'failed', '{"skills": "none"}');
 
-
-
+--
 -- PostgreSQL database dump complete
 --
-

--- a/server/db/migration/0005_pass_evaluation_migration.up.sql
+++ b/server/db/migration/0005_pass_evaluation_migration.up.sql
@@ -5,19 +5,18 @@ CREATE TYPE pass_status AS ENUM ('passed', 'failed', 'not_assessed');
 
 -- Step 2: Add a new column with the ENUM type
 ALTER TABLE course_phase_participation
-ADD COLUMN pass_status pass_status DEFAULT 'not_assessed';
+ADD COLUMN pass_status pass_status DEFAULT 'not_assessed'::pass_status;
 
 -- Step 3: Migrate data from the old `passed` column to the new column
 UPDATE course_phase_participation
 SET pass_status = CASE
-    WHEN passed = true THEN 'passed'
-    WHEN passed = false THEN 'failed'
-    ELSE 'not_assessed'
+    WHEN passed = true THEN 'passed'::pass_status
+    WHEN passed = false THEN 'failed'::pass_status
+    ELSE 'not_assessed'::pass_status
 END;
 
 -- Step 4: Drop the old `passed` column
 ALTER TABLE course_phase_participation
 DROP COLUMN passed;
-
 
 COMMIT;

--- a/server/db/migration/0005_pass_evaluation_migration.up.sql
+++ b/server/db/migration/0005_pass_evaluation_migration.up.sql
@@ -1,0 +1,23 @@
+BEGIN;
+
+-- Step 1: Create the new ENUM type
+CREATE TYPE pass_status AS ENUM ('passed', 'failed', 'not_assessed');
+
+-- Step 2: Add a new column with the ENUM type
+ALTER TABLE course_phase_participation
+ADD COLUMN pass_status pass_status DEFAULT 'not_assessed';
+
+-- Step 3: Migrate data from the old `passed` column to the new column
+UPDATE course_phase_participation
+SET pass_status = CASE
+    WHEN passed = true THEN 'passed'
+    WHEN passed = false THEN 'failed'
+    ELSE 'not_assessed'
+END;
+
+-- Step 4: Drop the old `passed` column
+ALTER TABLE course_phase_participation
+DROP COLUMN passed;
+
+
+COMMIT;

--- a/server/db/query/course_phase_participation.sql
+++ b/server/db/query/course_phase_participation.sql
@@ -11,14 +11,17 @@ SELECT * FROM course_phase_participation
 WHERE course_participation_id = $1;
 
 -- name: CreateCoursePhaseParticipation :one
-INSERT INTO course_phase_participation (id, course_participation_id, course_phase_id, passed, meta_data)
+INSERT INTO course_phase_participation (id, course_participation_id, course_phase_id, pass_status, meta_data)
 VALUES ($1, $2, $3, $4, $5)
 RETURNING *;
 
 -- name: UpdateCoursePhaseParticipation :one
 UPDATE course_phase_participation
 SET 
-    passed = COALESCE($2, passed),
+    pass_status = CASE
+                    WHEN $2 IS NOT NULL THEN $2::pass_status
+                    ELSE pass_status
+                 END,
     meta_data = meta_data || $3
 WHERE id = $1
 RETURNING *;

--- a/server/db/query/course_phase_participation.sql
+++ b/server/db/query/course_phase_participation.sql
@@ -15,16 +15,12 @@ INSERT INTO course_phase_participation (id, course_participation_id, course_phas
 VALUES ($1, $2, $3, $4, $5)
 RETURNING *;
 
--- name: UpdateCoursePhaseParticipation :one
+-- name: UpdateCoursePhaseParticipation :exec
 UPDATE course_phase_participation
 SET 
-    pass_status = CASE
-                    WHEN $2 IS NOT NULL THEN $2::pass_status
-                    ELSE pass_status
-                 END,
+    pass_status = COALESCE($2, pass_status),   
     meta_data = meta_data || $3
-WHERE id = $1
-RETURNING *;
+WHERE id = $1;
 
 -- name: GetCoursePhaseParticipationByCourseParticipationAndCoursePhase :one
 SELECT * FROM course_phase_participation


### PR DESCRIPTION
This pull request introduces several changes to the `coursePhaseParticipation` module, mainly focusing on replacing the `Passed` boolean field with a new `PassStatus` enum type. Additionally, it includes updates to related data transfer objects (DTOs), service methods, and tests to accommodate this change.

The migration is made to allow for distinction between 'not_assessed' and student 'failed' the component. This is with a simple true/false passed not possible.