### PR TITLE
removing subpath and stripping url instead

### DIFF
--- a/.github/workflows/build-and-push-clients.yml
+++ b/.github/workflows/build-and-push-clients.yml
@@ -47,7 +47,5 @@ jobs:
       docker-context: ./clients/template_component
       build-args: |
         "IMAGE_TAG=${{ needs.build-and-push-clients-base.outputs.image_tag }}"
-        "CLIENT_HOST=${{ vars.CLIENT_HOST }}"
         "SERVER_HOST=${{ vars.SERVER_HOST }}"
-        "TEMPLATE_COMPONENT_SUBPATH=${{ vars.TEMPLATE_COMPONENT_SUBPATH }}"
     secrets: inherit

--- a/clients/template_component/Dockerfile
+++ b/clients/template_component/Dockerfile
@@ -1,14 +1,9 @@
 ARG IMAGE_TAG
 FROM ghcr.io/ls1intum/prompt2/prompt-clients-base:${IMAGE_TAG} AS core-base
 
-# can also be dynamically in ENV Variables
 ARG SERVER_HOST
-# MUST BE defined in repository env variables as it is required for the build
-# ENV Variables are not available at build time
-ARG TEMPLATE_COMPONENT_SUBPATH
 
 ENV REACT_APP_SERVER_HOST=$SERVER_HOST
-ENV REACT_TEMPLATE_COMPONENT_SUBPATH=$TEMPLATE_COMPONENT_SUBPATH
 
 WORKDIR /app/template_component
 COPY . ./
@@ -18,10 +13,8 @@ RUN yarn build
 
 # Build the final image
 FROM nginx:stable-alpine
-# using arg to have it available at build time!
-ARG TEMPLATE_COMPONENT_SUBPATH 
-# Copy the build output to the subfolder, where the component shall be serving
-COPY --from=core-base /app/template_component/build /usr/share/nginx/html/${TEMPLATE_COMPONENT_SUBPATH}
+
+COPY --from=core-base /app/template_component/build /usr/share/nginx/html
 COPY --from=core-base /app/nginx/nginx.conf /etc/nginx/conf.d/default.conf
 EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]

--- a/clients/template_component/webpack.config.ts
+++ b/clients/template_component/webpack.config.ts
@@ -19,14 +19,6 @@ const __dirname = path.dirname(__filename)
 const config: (env: Record<string, string>) => container.Configuration = (env) => {
   const getVariable = (name: string) => env[name] ?? process.env[name]
 
-  // Here we only need the subdomain. Leave empty if deployed at someURL.com/
-  // Only fill out if deployed at someURL.com/subdomain/
-  let deploymentPath = getVariable('REACT_TEMPLATE_COMPONENT_SUBPATH')
-  if (deploymentPath !== '') {
-    deploymentPath = '/' + deploymentPath + '/'
-  } else {
-    deploymentPath = 'auto'
-  }
   const IS_DEV = getVariable('NODE_ENV') !== 'production'
   const deps = packageJson.dependencies
 
@@ -72,7 +64,7 @@ const config: (env: Record<string, string>) => container.Configuration = (env) =
     output: {
       filename: '[name].[contenthash].js',
       path: path.resolve(__dirname, 'build'),
-      publicPath: deploymentPath, // Whole Domain is crucial when deployed under other domain!
+      publicPath: 'auto', // Whole Domain is crucial when deployed under other domain!
     },
     resolve: {
       extensions: ['.ts', '.tsx', '.js', '.jsx'],

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -89,11 +89,11 @@ services:
       - TZ=Europe/Berlin
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.template.rule=Host(`${SERVER_HOST}`) && PathPrefix(`/template`)"
-      - "traefik.http.routers.template.stripprefix.prefixes=/template"
-      - "traefik.http.routers.template.stripprefix.forceSlash=false"
+      - "traefik.http.routers.template.rule=Host(`${SERVER_HOST}`) && PathPrefix(`/${TEMPLATE_COMPONENT_SUBPATH}`)"
       - "traefik.http.routers.template.entrypoints=websecure"
       - "traefik.http.routers.template.tls.certresolver=letsencrypt"
+      - "traefik.http.middlewares.template-strip-prefix.stripPrefix.prefixes=/${TEMPLATE_COMPONENT_SUBPATH}"
+      - "traefik.http.routers.template.middlewares=template-strip-prefix,template-compress"
       - "traefik.http.middlewares.template-compress.compress=true"
     expose:
       - "80"

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -90,6 +90,8 @@ services:
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.template.rule=Host(`${SERVER_HOST}`) && PathPrefix(`/template`)"
+      - "traefik.http.routers.template.stripprefix.prefixes=/template"
+      - "traefik.http.routers.template.stripprefix.forceSlash=false"
       - "traefik.http.routers.template.entrypoints=websecure"
       - "traefik.http.routers.template.tls.certresolver=letsencrypt"
       - "traefik.http.middlewares.template-compress.compress=true"


### PR DESCRIPTION
This is stripping the URL in the reverse proxy and removes the /template such that the components do not need to know under which path they are deployed. 