### PR TITLE
Modifying answer export

### DIFF
--- a/clients/core/public/env.js
+++ b/clients/core/public/env.js
@@ -1,6 +1,6 @@
 // these are just the defaults, which are overwritten via env.template.js at production
 window.env = {
-    REACT_APP_CORE_HOST: 'http://localhost:8080',
-    REACT_APP_KEYCLOAK_HOST: 'http://localhost:8081',
-    REACT_APP_KEYCLOAK_REALM_NAME: 'prompt',
+    CORE_HOST: 'http://localhost:8080',
+    KEYCLOAK_HOST: 'http://localhost:8081',
+    KEYCLOAK_REALM_NAME: 'prompt',
   }

--- a/clients/core/src/CourseConfigurator/PhaseNode/PhaseNode.tsx
+++ b/clients/core/src/CourseConfigurator/PhaseNode/PhaseNode.tsx
@@ -114,7 +114,6 @@ export function PhaseNode({ id, selected }: { id: string; selected?: boolean }) 
           {phaseType?.name === 'Application' &&
             (!phaseType?.provided_output_meta_data ||
               phaseType?.provided_output_meta_data.length === 0) && (
-              // TODO
               <TooltipProvider>
                 <Tooltip>
                   <TooltipTrigger asChild>

--- a/clients/core/src/CourseConfigurator/PhaseNode/PhaseNode.tsx
+++ b/clients/core/src/CourseConfigurator/PhaseNode/PhaseNode.tsx
@@ -3,7 +3,7 @@ import { Handle, Position, useHandleConnections, useReactFlow } from '@xyflow/re
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
-import { Pen, ArrowDownToLine, ArrowUpFromLine, TriangleAlert } from 'lucide-react'
+import { Pen, TriangleAlert, FileInput, FileOutput } from 'lucide-react'
 import { Badge } from '@/components/ui/badge'
 import { MetaDataBadges } from './components/MetaDataBadges'
 import { useCourseConfigurationState } from '@/zustand/useCourseConfigurationStore'
@@ -137,7 +137,7 @@ export function PhaseNode({ id, selected }: { id: string; selected?: boolean }) 
           {phaseType?.required_input_meta_data && phaseType.required_input_meta_data.length > 0 && (
             <MetaDataBadges
               metaData={phaseType.required_input_meta_data}
-              icon={<ArrowDownToLine className='w-4 h-4 text-green-500' />}
+              icon={<FileInput className='w-5 h-5 text-green-500' />}
               label='Required Input Metadata'
               providedMetaData={incomingMetaData}
             />
@@ -147,7 +147,7 @@ export function PhaseNode({ id, selected }: { id: string; selected?: boolean }) 
             phaseType.provided_output_meta_data.length > 0 && (
               <MetaDataBadges
                 metaData={phaseType.provided_output_meta_data}
-                icon={<ArrowUpFromLine className='w-4 h-4 text-green-500' />}
+                icon={<FileOutput className='w-5 h-5 text-green-500' />}
                 label='Provided Output Metadata'
               />
             )}

--- a/clients/core/src/CourseConfigurator/PhaseNode/components/MetaDataBadges.tsx
+++ b/clients/core/src/CourseConfigurator/PhaseNode/components/MetaDataBadges.tsx
@@ -3,13 +3,13 @@ import { Badge } from '@/components/ui/badge'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 import { MetaDataItem } from '@/interfaces/course_phase_type'
 import { getMetaDataStatus } from './utils/getBadgeStatus'
+import { renderBadgeTooltipContent } from './utils/renderBadgeTooltip'
 
 interface MetaDataBadgesProps {
   metaData: MetaDataItem[]
   icon: React.ReactNode
   label: string
   providedMetaData?: MetaDataItem[]
-  isApplicationPhase?: boolean
 }
 
 export const MetaDataBadges = ({
@@ -28,14 +28,13 @@ export const MetaDataBadges = ({
             const {
               color,
               icon: statusIcon,
-              tooltip,
+              tooltip: errorTooltip,
             } = getMetaDataStatus(item.name, item.type, providedMetaData)
             return (
               <TooltipProvider key={index}>
                 <Tooltip>
                   <TooltipTrigger>
                     <Badge
-                      key={index}
                       variant='secondary'
                       className={`text-xs font-normal ${color} flex items-center gap-1`}
                     >
@@ -44,74 +43,7 @@ export const MetaDataBadges = ({
                     </Badge>
                   </TooltipTrigger>
                   <TooltipContent>
-                    {item.name === 'applicationAnswers' ? (
-                      tooltip ? (
-                        <p>{tooltip}</p>
-                      ) : (
-                        <div>
-                          {(() => {
-                            try {
-                              // Parse the item.type; if it fails, fallback to showing the raw string.
-                              const questions = JSON.parse(item.type) as {
-                                key: string
-                                type: string
-                              }[]
-                              return (
-                                <div>
-                                  <span className='font-bold'>
-                                    {!providedMetaData ? 'Exported' : 'Expected'} Questions:
-                                  </span>
-                                  <ul className='list-disc pl-5'>
-                                    {questions.map((question, qIndex) => (
-                                      <li key={qIndex}>
-                                        <span className='font-bold'>{question.key}:</span>{' '}
-                                        {question.type}
-                                      </li>
-                                    ))}
-                                  </ul>
-                                  {providedMetaData &&
-                                    questions.length === 0 &&
-                                    'No specific questions expected'}
-                                </div>
-                              )
-                            } catch (error) {
-                              return <div>{`Name: ${item.name}, Type: ${item.type}`}</div>
-                            }
-                          })()}
-                        </div>
-                      )
-                    ) : item.name === 'additionalScores' ? (
-                      tooltip ? (
-                        <p>{tooltip}</p>
-                      ) : (
-                        <div>
-                          {(() => {
-                            try {
-                              const scores = JSON.parse(item.type) as string[]
-                              return (
-                                <div>
-                                  <span className='font-bold'>
-                                    {!providedMetaData ? 'Exported' : 'Expected'} Scores:
-                                  </span>
-                                  <ul className='list-disc pl-5'>
-                                    {scores.map((score, idx) => (
-                                      <li key={idx}>{score}</li>
-                                    ))}
-                                  </ul>
-                                  {providedMetaData &&
-                                    scores.length === 0 &&
-                                    'No specific scores expected'}
-                                </div>
-                              )
-                            } catch (error) {
-                              return <div>{`Name: ${item.name}, Type: ${item.type}`}</div>
-                            }
-                          })()}
-                        </div>
-                      )
-                    ) : (
-                      <p>{tooltip || `Name: ${item.name}, Type: ${item.type}`}</p>
-                    )}
+                    {renderBadgeTooltipContent(item, providedMetaData, errorTooltip)}
                   </TooltipContent>
                 </Tooltip>
               </TooltipProvider>

--- a/clients/core/src/CourseConfigurator/PhaseNode/components/MetaDataBadges.tsx
+++ b/clients/core/src/CourseConfigurator/PhaseNode/components/MetaDataBadges.tsx
@@ -1,14 +1,15 @@
 import React from 'react'
 import { Badge } from '@/components/ui/badge'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
-import { CheckCircle, AlertCircle, AlertTriangle } from 'lucide-react'
 import { MetaDataItem } from '@/interfaces/course_phase_type'
+import { getMetaDataStatus } from './utils/getBadgeStatus'
 
 interface MetaDataBadgesProps {
   metaData: MetaDataItem[]
   icon: React.ReactNode
   label: string
   providedMetaData?: MetaDataItem[]
+  isApplicationPhase?: boolean
 }
 
 export const MetaDataBadges = ({
@@ -17,39 +18,6 @@ export const MetaDataBadges = ({
   label,
   providedMetaData,
 }: MetaDataBadgesProps): JSX.Element => {
-  const getMetaDataStatus = (
-    name: string,
-    type: string,
-  ): { color: string; icon: React.ReactNode; tooltip?: string } => {
-    if (!providedMetaData) return { color: 'bg-secondary', icon: null }
-
-    const matchingItems = providedMetaData.filter(
-      (meta) => meta.name === name && meta.type === type,
-    )
-
-    const wrongType = providedMetaData.filter((meta) => meta.name === name && meta.type !== type)
-
-    if (wrongType.length > 0) {
-      return {
-        color: 'bg-yellow-200 text-yellow-800',
-        icon: <AlertCircle className='w-3 h-3' />,
-        tooltip: 'Conflict (Wrong type): expecting type: ' + type,
-      }
-    }
-    if (matchingItems.length === 0)
-      return {
-        color: 'bg-red-200 text-red-800',
-        icon: <AlertCircle className='w-3 h-3' />,
-        tooltip: 'Missing meta data with name: ' + name + ' and type: ' + type,
-      }
-    if (matchingItems.length === 1)
-      return { color: 'bg-green-200 text-green-800', icon: <CheckCircle className='w-3 h-3' /> }
-    return {
-      color: 'bg-yellow-200 text-yellow-800',
-      icon: <AlertTriangle className='w-3 h-3' />,
-      tooltip: 'Conflict: metadata provided multiple times',
-    }
-  }
   return (
     <div className='flex items-start space-x-2 mb-2'>
       <div className='mt-1'>{icon}</div>
@@ -57,7 +25,11 @@ export const MetaDataBadges = ({
         <div className='text-xs font-semibold text-secondary-foreground mb-1'>{label}</div>
         <div className='flex flex-wrap gap-1'>
           {metaData.map((item, index) => {
-            const { color, icon: statusIcon, tooltip } = getMetaDataStatus(item.name, item.type)
+            const {
+              color,
+              icon: statusIcon,
+              tooltip,
+            } = getMetaDataStatus(item.name, item.type, providedMetaData)
             return (
               <TooltipProvider key={index}>
                 <Tooltip>
@@ -72,7 +44,74 @@ export const MetaDataBadges = ({
                     </Badge>
                   </TooltipTrigger>
                   <TooltipContent>
-                    <p>{tooltip || `Name: ${item.name}, Type: ${item.type}`}</p>
+                    {item.name === 'applicationAnswers' ? (
+                      tooltip ? (
+                        <p>{tooltip}</p>
+                      ) : (
+                        <div>
+                          {(() => {
+                            try {
+                              // Parse the item.type; if it fails, fallback to showing the raw string.
+                              const questions = JSON.parse(item.type) as {
+                                key: string
+                                type: string
+                              }[]
+                              return (
+                                <div>
+                                  <span className='font-bold'>
+                                    {!providedMetaData ? 'Exported' : 'Expected'} Questions:
+                                  </span>
+                                  <ul className='list-disc pl-5'>
+                                    {questions.map((question, qIndex) => (
+                                      <li key={qIndex}>
+                                        <span className='font-bold'>{question.key}:</span>{' '}
+                                        {question.type}
+                                      </li>
+                                    ))}
+                                  </ul>
+                                  {providedMetaData &&
+                                    questions.length === 0 &&
+                                    'No specific questions expected'}
+                                </div>
+                              )
+                            } catch (error) {
+                              return <div>{`Name: ${item.name}, Type: ${item.type}`}</div>
+                            }
+                          })()}
+                        </div>
+                      )
+                    ) : item.name === 'additionalScores' ? (
+                      tooltip ? (
+                        <p>{tooltip}</p>
+                      ) : (
+                        <div>
+                          {(() => {
+                            try {
+                              const scores = JSON.parse(item.type) as string[]
+                              return (
+                                <div>
+                                  <span className='font-bold'>
+                                    {!providedMetaData ? 'Exported' : 'Expected'} Scores:
+                                  </span>
+                                  <ul className='list-disc pl-5'>
+                                    {scores.map((score, idx) => (
+                                      <li key={idx}>{score}</li>
+                                    ))}
+                                  </ul>
+                                  {providedMetaData &&
+                                    scores.length === 0 &&
+                                    'No specific scores expected'}
+                                </div>
+                              )
+                            } catch (error) {
+                              return <div>{`Name: ${item.name}, Type: ${item.type}`}</div>
+                            }
+                          })()}
+                        </div>
+                      )
+                    ) : (
+                      <p>{tooltip || `Name: ${item.name}, Type: ${item.type}`}</p>
+                    )}
                   </TooltipContent>
                 </Tooltip>
               </TooltipProvider>

--- a/clients/core/src/CourseConfigurator/PhaseNode/components/utils/getBadgeStatus.tsx
+++ b/clients/core/src/CourseConfigurator/PhaseNode/components/utils/getBadgeStatus.tsx
@@ -1,0 +1,113 @@
+import { AlertCircle, AlertTriangle, CheckCircle } from 'lucide-react'
+
+export const getMetaDataStatus = (
+  name: string,
+  type: string,
+  providedMetaData?: { name: string; type: string }[],
+): { color: string; icon: React.ReactNode; tooltip?: string } => {
+  if (!providedMetaData) return { color: 'bg-secondary', icon: null }
+
+  const matchingItems = providedMetaData.filter((meta) => meta.name === name && meta.type === type)
+  const wrongType = providedMetaData.filter((meta) => meta.name === name && meta.type !== type)
+
+  if (name === 'applicationAnswers') {
+    try {
+      // Parse the item.type; if it fails, fallback to showing the raw string.
+      const expectedAnswers = JSON.parse(type) as {
+        key: string
+        type: string
+      }[]
+
+      const providedInputAnswers = providedMetaData.find(
+        (meta) => meta.name === 'applicationAnswers',
+      )
+      if (providedInputAnswers === undefined) {
+        return {
+          color: 'bg-red-200 text-red-800',
+          icon: <AlertCircle className='w-3 h-3' />,
+          tooltip: 'Application Answers are missing',
+        }
+      } else {
+        const providedQuestions = JSON.parse(providedInputAnswers.type) as {
+          key: string
+          type: string
+        }[]
+        const missingQuestions = expectedAnswers.filter(
+          (expected) =>
+            !providedQuestions.some(
+              (provided) => provided.key === expected.key && provided.type === expected.type,
+            ),
+        )
+        if (missingQuestions.length === 0) {
+          return { color: 'bg-green-200 text-green-800', icon: <CheckCircle className='w-3 h-3' /> }
+        } else {
+          return {
+            color: 'bg-yellow-200 text-yellow-800',
+            icon: <AlertTriangle className='w-3 h-3' />,
+            tooltip:
+              'Missing or wrong type questions: ' + missingQuestions.map((q) => q.key).join(', '),
+          }
+        }
+      }
+    } catch (error) {
+      return {
+        color: 'bg-red-200 text-red-800',
+        icon: <AlertCircle className='w-3 h-3' />,
+        tooltip: 'Cannot assess if all expected questions are provided',
+      }
+    }
+  } else if (name === 'additionalScores') {
+    try {
+      // Parse the item.type; if it fails, fallback to showing the raw string.
+      const expectedScores = JSON.parse(type) as string[]
+
+      const providedScore = providedMetaData.find((meta) => meta.name === 'additionalScores')
+      if (providedScore === undefined) {
+        return {
+          color: 'bg-red-200 text-red-800',
+          icon: <AlertCircle className='w-3 h-3' />,
+          tooltip: 'Additional Scores are missing',
+        }
+      } else {
+        const providedScores = JSON.parse(providedScore.type) as string[]
+        const missingScores = expectedScores.filter(
+          (expected) => !providedScores.some((provided) => provided === expected),
+        )
+        if (missingScores.length === 0) {
+          return { color: 'bg-green-200 text-green-800', icon: <CheckCircle className='w-3 h-3' /> }
+        } else {
+          return {
+            color: 'bg-yellow-200 text-yellow-800',
+            icon: <AlertTriangle className='w-3 h-3' />,
+            tooltip: 'Missing or wrong type questions: ' + missingScores.join(', '),
+          }
+        }
+      }
+    } catch (error) {
+      return {
+        color: 'bg-red-200 text-red-800',
+        icon: <AlertCircle className='w-3 h-3' />,
+        tooltip: 'Cannot assess if all expected scores are provided',
+      }
+    }
+  } else if (wrongType.length > 0) {
+    return {
+      color: 'bg-yellow-200 text-yellow-800',
+      icon: <AlertCircle className='w-3 h-3' />,
+      tooltip: 'Conflict (Wrong type): expecting type: ' + type,
+    }
+  }
+  if (matchingItems.length === 0)
+    return {
+      color: 'bg-red-200 text-red-800',
+      icon: <AlertCircle className='w-3 h-3' />,
+      tooltip: 'Missing meta data with name: ' + name + ' and type: ' + type,
+    }
+  if (matchingItems.length === 1)
+    return { color: 'bg-green-200 text-green-800', icon: <CheckCircle className='w-3 h-3' /> }
+  return {
+    color: 'bg-yellow-200 text-yellow-800',
+    icon: <AlertTriangle className='w-3 h-3' />,
+    tooltip: 'Conflict: metadata provided multiple times',
+  }
+}

--- a/clients/core/src/CourseConfigurator/PhaseNode/components/utils/getBadgeStatus.tsx
+++ b/clients/core/src/CourseConfigurator/PhaseNode/components/utils/getBadgeStatus.tsx
@@ -1,110 +1,128 @@
+import React from 'react'
 import { AlertCircle, AlertTriangle, CheckCircle } from 'lucide-react'
 
+interface ParsedQuestion {
+  key: string
+  type: string
+}
+
+/**
+ * Helper: Parses a JSON string safely.
+ * @param jsonString The JSON string to parse.
+ * @returns The parsed data or null if parsing failed.
+ */
+const safeParseJSON = <T,>(jsonString: string): T | null => {
+  try {
+    return JSON.parse(jsonString) as T
+  } catch (error) {
+    return null
+  }
+}
+
+/**
+ * Helper: Returns an error response.
+ */
+const errorResponse = (tooltip: string) => ({
+  color: 'bg-red-200 text-red-800',
+  icon: <AlertCircle className='w-3 h-3' />,
+  tooltip,
+})
+
+/**
+ * Returns metadata status based on provided and expected metadata.
+ */
 export const getMetaDataStatus = (
   name: string,
   type: string,
   providedMetaData?: { name: string; type: string }[],
 ): { color: string; icon: React.ReactNode; tooltip?: string } => {
+  // If no provided metadata, default fallback
   if (!providedMetaData) return { color: 'bg-secondary', icon: null }
 
+  // Filter the provided metadata for matching or wrong types
   const matchingItems = providedMetaData.filter((meta) => meta.name === name && meta.type === type)
-  const wrongType = providedMetaData.filter((meta) => meta.name === name && meta.type !== type)
+  const wrongTypeItems = providedMetaData.filter((meta) => meta.name === name && meta.type !== type)
 
   if (name === 'applicationAnswers') {
-    try {
-      // Parse the item.type; if it fails, fallback to showing the raw string.
-      const expectedAnswers = JSON.parse(type) as {
-        key: string
-        type: string
-      }[]
+    // Parse expected questions
+    const expectedQuestions = safeParseJSON<ParsedQuestion[]>(type)
+    if (!expectedQuestions) {
+      return errorResponse('Cannot assess if all expected questions are provided')
+    }
 
-      const providedInputAnswers = providedMetaData.find(
-        (meta) => meta.name === 'applicationAnswers',
-      )
-      if (providedInputAnswers === undefined) {
-        return {
-          color: 'bg-red-200 text-red-800',
-          icon: <AlertCircle className='w-3 h-3' />,
-          tooltip: 'Application Answers are missing',
-        }
-      } else {
-        const providedQuestions = JSON.parse(providedInputAnswers.type) as {
-          key: string
-          type: string
-        }[]
-        const missingQuestions = expectedAnswers.filter(
-          (expected) =>
-            !providedQuestions.some(
-              (provided) => provided.key === expected.key && provided.type === expected.type,
-            ),
-        )
-        if (missingQuestions.length === 0) {
-          return { color: 'bg-green-200 text-green-800', icon: <CheckCircle className='w-3 h-3' /> }
-        } else {
-          return {
-            color: 'bg-yellow-200 text-yellow-800',
-            icon: <AlertTriangle className='w-3 h-3' />,
-            tooltip:
-              'Missing or wrong type questions: ' + missingQuestions.map((q) => q.key).join(', '),
-          }
-        }
-      }
-    } catch (error) {
+    // Find the provided applicationAnswers metadata and parse it
+    const providedEntry = providedMetaData.find((meta) => meta.name === 'applicationAnswers')
+    if (!providedEntry) {
+      return errorResponse('Application Answers are not provided')
+    }
+
+    const providedQuestions = safeParseJSON<ParsedQuestion[]>(providedEntry.type)
+    if (!providedQuestions) {
+      return errorResponse('Cannot assess provided questions: invalid JSON')
+    }
+
+    // Identify missing questions (either missing key or mismatched type)
+    const missingQuestions = expectedQuestions.filter(
+      (expected) =>
+        !providedQuestions.some(
+          (provided) => provided.key === expected.key && provided.type === expected.type,
+        ),
+    )
+
+    if (missingQuestions.length === 0) {
+      return { color: 'bg-green-200 text-green-800', icon: <CheckCircle className='w-3 h-3' /> }
+    } else {
       return {
-        color: 'bg-red-200 text-red-800',
-        icon: <AlertCircle className='w-3 h-3' />,
-        tooltip: 'Cannot assess if all expected questions are provided',
+        color: 'bg-yellow-200 text-yellow-800',
+        icon: <AlertTriangle className='w-3 h-3' />,
+        tooltip:
+          'Missing or wrong type questions: ' + missingQuestions.map((q) => q.key).join(', '),
       }
     }
   } else if (name === 'additionalScores') {
-    try {
-      // Parse the item.type; if it fails, fallback to showing the raw string.
-      const expectedScores = JSON.parse(type) as string[]
+    // Parse expected scores (assumed to be an array of strings)
+    const expectedScores = safeParseJSON<string[]>(type)
+    if (!expectedScores) {
+      return errorResponse('Cannot assess if all expected scores are provided')
+    }
 
-      const providedScore = providedMetaData.find((meta) => meta.name === 'additionalScores')
-      if (providedScore === undefined) {
-        return {
-          color: 'bg-red-200 text-red-800',
-          icon: <AlertCircle className='w-3 h-3' />,
-          tooltip: 'Additional Scores are missing',
-        }
-      } else {
-        const providedScores = JSON.parse(providedScore.type) as string[]
-        const missingScores = expectedScores.filter(
-          (expected) => !providedScores.some((provided) => provided === expected),
-        )
-        if (missingScores.length === 0) {
-          return { color: 'bg-green-200 text-green-800', icon: <CheckCircle className='w-3 h-3' /> }
-        } else {
-          return {
-            color: 'bg-yellow-200 text-yellow-800',
-            icon: <AlertTriangle className='w-3 h-3' />,
-            tooltip: 'Missing or wrong type questions: ' + missingScores.join(', '),
-          }
-        }
-      }
-    } catch (error) {
+    const providedEntry = providedMetaData.find((meta) => meta.name === 'additionalScores')
+    if (!providedEntry) {
+      return errorResponse('Additional Scores are not provided')
+    }
+
+    const providedScores = safeParseJSON<string[]>(providedEntry.type)
+    if (!providedScores) {
+      return errorResponse('Cannot assess provided scores: invalid JSON')
+    }
+
+    const missingScores = expectedScores.filter((expected) => !providedScores.includes(expected))
+
+    if (missingScores.length === 0) {
+      return { color: 'bg-green-200 text-green-800', icon: <CheckCircle className='w-3 h-3' /> }
+    } else {
       return {
-        color: 'bg-red-200 text-red-800',
-        icon: <AlertCircle className='w-3 h-3' />,
-        tooltip: 'Cannot assess if all expected scores are provided',
+        color: 'bg-yellow-200 text-yellow-800',
+        icon: <AlertTriangle className='w-3 h-3' />,
+        tooltip: 'Missing or wrong scores: ' + missingScores.join(', '),
       }
     }
-  } else if (wrongType.length > 0) {
+  } else if (wrongTypeItems.length > 0) {
     return {
       color: 'bg-yellow-200 text-yellow-800',
       icon: <AlertCircle className='w-3 h-3' />,
       tooltip: 'Conflict (Wrong type): expecting type: ' + type,
     }
-  }
-  if (matchingItems.length === 0)
+  } else if (matchingItems.length === 0) {
     return {
       color: 'bg-red-200 text-red-800',
       icon: <AlertCircle className='w-3 h-3' />,
-      tooltip: 'Missing meta data with name: ' + name + ' and type: ' + type,
+      tooltip: `${name} is not provided`,
     }
-  if (matchingItems.length === 1)
+  } else if (matchingItems.length === 1) {
     return { color: 'bg-green-200 text-green-800', icon: <CheckCircle className='w-3 h-3' /> }
+  }
+
   return {
     color: 'bg-yellow-200 text-yellow-800',
     icon: <AlertTriangle className='w-3 h-3' />,

--- a/clients/core/src/CourseConfigurator/PhaseNode/components/utils/renderBadgeTooltip.tsx
+++ b/clients/core/src/CourseConfigurator/PhaseNode/components/utils/renderBadgeTooltip.tsx
@@ -1,0 +1,49 @@
+import { MetaDataItem } from '@/interfaces/course_phase_type'
+import { renderTooltipList } from './renderTooltipList'
+
+/** Helper: Renders tooltip content based on meta-data name */
+export const renderBadgeTooltipContent = (
+  item: MetaDataItem,
+  providedMetaData?: MetaDataItem[],
+  errorTooltip?: string,
+): JSX.Element => {
+  // If an error tooltip message exists, use it
+  if (errorTooltip) {
+    return <p>{errorTooltip}</p>
+  }
+
+  if (item.name === 'applicationAnswers') {
+    try {
+      const questions = JSON.parse(item.type) as { key: string; type: string }[]
+      const title = !providedMetaData ? 'Exported Questions' : 'Expected Questions'
+      return renderTooltipList(title, questions)
+    } catch (error) {
+      return (
+        <div>
+          <span className='font-bold'>{item.name}:</span> {item.type}
+        </div>
+      )
+    }
+  }
+
+  if (item.name === 'additionalScores') {
+    try {
+      // Assuming type is a JSON-stringified array of scores
+      const scores = JSON.parse(item.type) as string[]
+      const title = !providedMetaData ? 'Exported Scores' : 'Expected Scores'
+      return renderTooltipList(title, scores)
+    } catch (error) {
+      return (
+        <div>
+          <span className='font-bold'>{item.name}:</span> {item.type}
+        </div>
+      )
+    }
+  }
+
+  return (
+    <div>
+      <span className='font-bold'>{item.name}:</span> {item.type}
+    </div>
+  )
+}

--- a/clients/core/src/CourseConfigurator/PhaseNode/components/utils/renderTooltipList.tsx
+++ b/clients/core/src/CourseConfigurator/PhaseNode/components/utils/renderTooltipList.tsx
@@ -1,0 +1,27 @@
+export const renderTooltipList = (
+  title: string,
+  items: { key: string; type: string }[] | string[],
+) => {
+  if (Array.isArray(items) && items.length === 0) {
+    return <p>No specific {title.toLowerCase()} expected</p>
+  }
+
+  return (
+    <div>
+      <span className='font-bold'>{title}:</span>
+      <ul className='list-disc pl-5'>
+        {Array.isArray(items)
+          ? items.map((item, index) =>
+              typeof item === 'string' ? (
+                <li key={index}>{item}</li>
+              ) : (
+                <li key={index}>
+                  <span className='font-bold'>{item.key}:</span> {item.type}
+                </li>
+              ),
+            )
+          : null}
+      </ul>
+    </div>
+  )
+}

--- a/clients/core/src/CourseConfigurator/handlers/useCourseConfiguratorDataSetup.ts
+++ b/clients/core/src/CourseConfigurator/handlers/useCourseConfiguratorDataSetup.ts
@@ -121,16 +121,15 @@ export function useCourseConfiguratorDataSetup() {
           fetchedApplicationForm &&
           !isAdditionalScoresPending
         ) {
+          const applicationAnswers: { key: string; type: string }[] = []
+
           fetchedApplicationForm.questions_multi_select
             .filter(
               (question) =>
                 question.access_key !== undefined && question.accessible_for_other_phases === true,
             )
             .forEach((question) => {
-              additionalMetaData.push({
-                name: question.access_key || 'undefined',
-                type: 'array',
-              })
+              applicationAnswers.push({ key: question.access_key ?? '', type: 'Multi-Select' })
             })
 
           fetchedApplicationForm.questions_text
@@ -139,22 +138,29 @@ export function useCourseConfiguratorDataSetup() {
                 question.access_key !== undefined && question.accessible_for_other_phases === true,
             )
             .forEach((question) => {
-              additionalMetaData.push({
-                name: question.access_key || 'undefined',
-                type: 'string',
-              })
+              applicationAnswers.push({ key: question.access_key ?? '', type: 'Text' })
             })
 
-          if (fetchedAdditionalScores) {
-            fetchedAdditionalScores.forEach((score) => {
-              additionalMetaData.push({
-                name: score.name,
-                type: 'integer',
-              })
+          if (applicationAnswers.length > 0) {
+            additionalMetaData.push({
+              name: 'applicationAnswers',
+              // Convert the object array to a properly formatted JSON string
+              type: JSON.stringify(applicationAnswers),
             })
           }
 
-          additionalMetaData.push({ name: 'assessmentScore', type: 'integer' })
+          if (fetchedAdditionalScores) {
+            const additionScores: string[] = []
+            fetchedAdditionalScores.forEach((score) => {
+              additionScores.push(score.name)
+            })
+            additionalMetaData.push({
+              name: 'additionalScores',
+              type: JSON.stringify(additionScores),
+            })
+          }
+
+          additionalMetaData.push({ name: 'applicationScore', type: 'integer' })
         }
 
         appendCoursePhaseType({

--- a/server/db/query/course_phase_participation.sql
+++ b/server/db/query/course_phase_participation.sql
@@ -215,72 +215,73 @@ SELECT
          JOIN course_phase_type cpt
            ON cpt.id = dpm.course_phase_type_id
           AND cpt.name = 'Application'
-         CROSS JOIN LATERAL (
-             SELECT
-                 jsonb_object_agg(x.key, x.value) AS obj
-             FROM
-             (
-                  ----------------------------------------------------------
-                    -- (A) Always export applicationScore
-                  ----------------------------------------------------------
-                    SELECT 
-                        'applicationScore' AS key,
-                        to_jsonb(aasm.score) AS value
-                    FROM application_assessment aasm
-                    WHERE aasm.course_phase_participation_id = pcpp.id
-                      AND (dpm.course_phase_meta_data->'exportAnswers'->>'applicationScore') = 'true'
-                    
-                    UNION ALL
-
-                    ----------------------------------------------------------
-                    -- (B) For each text question with accessibleForOtherPhases=true,
-                    --     store the answer under the question's accessKey.
-                    ----------------------------------------------------------
-                    SELECT
-                        qt.access_key AS key,
-                        to_jsonb(aat.answer) AS value
-                    FROM application_question_text qt
-                    JOIN application_answer_text aat
-                      ON aat.application_question_id = qt.id
-                     AND aat.course_phase_participation_id = pcpp.id
-                    WHERE qt.course_phase_id = dpm.phase_id
-                      AND qt.accessible_for_other_phases = true
-                      AND qt.access_key IS NOT NULL
-                      AND qt.access_key != ''
-
-                    UNION ALL
-                    
-                    ----------------------------------------------------------
-                    -- (C) For each multi-select question with accessibleForOtherPhases=true,
-                    --     store the answer under the question's accessKey.
-                    ----------------------------------------------------------
-                    SELECT
-                        qm.access_key AS key,
-                        to_jsonb(aams.answer) AS value
-                    FROM application_question_multi_select qm
-                    JOIN application_answer_multi_select aams
-                      ON aams.application_question_id = qm.id
-                     AND aams.course_phase_participation_id = pcpp.id
-                    WHERE qm.course_phase_id = dpm.phase_id
-                      AND qm.accessible_for_other_phases = true
-                      AND qm.access_key IS NOT NULL
-                      AND qm.access_key != ''
-                
-                  UNION ALL
-
-                    ----------------------------------------------------------
-                    -- (D) Get all additional scores
-                    ----------------------------------------------------------
-                    SELECT
-                      question_config->>'key'  AS key,
-                      to_jsonb(
-                          pcpp.meta_data -> (question_config->>'key')
-                      )                       AS value
-                    FROM jsonb_array_elements(
-                            dpm.course_phase_meta_data->'additionalScores'
-                          ) question_config
-                
-             ) x
+          CROSS JOIN LATERAL (
+             SELECT jsonb_build_object(
+                     ----------------------------------------------------------
+                     -- (A) Application Score
+                     ----------------------------------------------------------
+                     'applicationScore', (
+                         SELECT to_jsonb(aasm.score)
+                         FROM application_assessment aasm
+                         WHERE aasm.course_phase_participation_id = pcpp.id
+                           AND (dpm.course_phase_meta_data->'exportAnswers'->>'applicationScore') = 'true'
+                     ),
+                     ----------------------------------------------------------
+                     -- (B) Additional Scores
+                     ----------------------------------------------------------
+                     'additionalScores', (
+                         SELECT jsonb_agg(
+                             jsonb_build_object(
+                               'key', question_config->>'key',
+                               'answer', pcpp.meta_data -> (question_config->>'key')
+                             )
+                         )
+                         FROM jsonb_array_elements(
+                                dpm.course_phase_meta_data->'additionalScores'
+                              ) question_config
+                     ),
+                     ----------------------------------------------------------
+                     -- (C) Aggregate Answers from text and multi-select questions
+                     ----------------------------------------------------------
+                     'applicationAnswers', (
+                         SELECT jsonb_agg(answer_obj)
+                         FROM (
+                            -- Text answers
+                            SELECT jsonb_build_object(
+                                'key', qt.access_key,
+                                'answer', to_jsonb(aat.answer),
+                                'order_num', qt.order_num, 
+                                'type', 'text'
+                            ) AS answer_obj
+                            FROM application_question_text qt
+                            JOIN application_answer_text aat
+                              ON aat.application_question_id = qt.id
+                             AND aat.course_phase_participation_id = pcpp.id
+                            WHERE qt.course_phase_id = dpm.phase_id
+                              AND qt.accessible_for_other_phases = true
+                              AND qt.access_key IS NOT NULL
+                              AND qt.access_key <> ''
+                            
+                            UNION ALL
+                            
+                            -- Multi-select answers
+                            SELECT jsonb_build_object(
+                                'key', qm.access_key,
+                                'answer', to_jsonb(aams.answer),
+                                'order_num', qm.order_num, 
+                                'type', 'multiselect'
+                            ) AS answer_obj
+                            FROM application_question_multi_select qm
+                            JOIN application_answer_multi_select aams
+                              ON aams.application_question_id = qm.id
+                             AND aams.course_phase_participation_id = pcpp.id
+                            WHERE qm.course_phase_id = dpm.phase_id
+                              AND qm.accessible_for_other_phases = true
+                              AND qm.access_key IS NOT NULL
+                              AND qm.access_key <> ''
+                         ) answer_union
+                 )
+             ) AS obj
          ) appdata
        ),
        '{}'

--- a/server/db/sqlc/course_phase_participation.sql.go
+++ b/server/db/sqlc/course_phase_participation.sql.go
@@ -289,72 +289,73 @@ SELECT
          JOIN course_phase_type cpt
            ON cpt.id = dpm.course_phase_type_id
           AND cpt.name = 'Application'
-         CROSS JOIN LATERAL (
-             SELECT
-                 jsonb_object_agg(x.key, x.value) AS obj
-             FROM
-             (
-                  ----------------------------------------------------------
-                    -- (A) Always export applicationScore
-                  ----------------------------------------------------------
-                    SELECT 
-                        'applicationScore' AS key,
-                        to_jsonb(aasm.score) AS value
-                    FROM application_assessment aasm
-                    WHERE aasm.course_phase_participation_id = pcpp.id
-                      AND (dpm.course_phase_meta_data->'exportAnswers'->>'applicationScore') = 'true'
-                    
-                    UNION ALL
-
-                    ----------------------------------------------------------
-                    -- (B) For each text question with accessibleForOtherPhases=true,
-                    --     store the answer under the question's accessKey.
-                    ----------------------------------------------------------
-                    SELECT
-                        qt.access_key AS key,
-                        to_jsonb(aat.answer) AS value
-                    FROM application_question_text qt
-                    JOIN application_answer_text aat
-                      ON aat.application_question_id = qt.id
-                     AND aat.course_phase_participation_id = pcpp.id
-                    WHERE qt.course_phase_id = dpm.phase_id
-                      AND qt.accessible_for_other_phases = true
-                      AND qt.access_key IS NOT NULL
-                      AND qt.access_key != ''
-
-                    UNION ALL
-                    
-                    ----------------------------------------------------------
-                    -- (C) For each multi-select question with accessibleForOtherPhases=true,
-                    --     store the answer under the question's accessKey.
-                    ----------------------------------------------------------
-                    SELECT
-                        qm.access_key AS key,
-                        to_jsonb(aams.answer) AS value
-                    FROM application_question_multi_select qm
-                    JOIN application_answer_multi_select aams
-                      ON aams.application_question_id = qm.id
-                     AND aams.course_phase_participation_id = pcpp.id
-                    WHERE qm.course_phase_id = dpm.phase_id
-                      AND qm.accessible_for_other_phases = true
-                      AND qm.access_key IS NOT NULL
-                      AND qm.access_key != ''
-                
-                  UNION ALL
-
-                    ----------------------------------------------------------
-                    -- (D) Get all additional scores
-                    ----------------------------------------------------------
-                    SELECT
-                      question_config->>'key'  AS key,
-                      to_jsonb(
-                          pcpp.meta_data -> (question_config->>'key')
-                      )                       AS value
-                    FROM jsonb_array_elements(
-                            dpm.course_phase_meta_data->'additionalScores'
-                          ) question_config
-                
-             ) x
+          CROSS JOIN LATERAL (
+             SELECT jsonb_build_object(
+                     ----------------------------------------------------------
+                     -- (A) Application Score
+                     ----------------------------------------------------------
+                     'applicationScore', (
+                         SELECT to_jsonb(aasm.score)
+                         FROM application_assessment aasm
+                         WHERE aasm.course_phase_participation_id = pcpp.id
+                           AND (dpm.course_phase_meta_data->'exportAnswers'->>'applicationScore') = 'true'
+                     ),
+                     ----------------------------------------------------------
+                     -- (B) Additional Scores
+                     ----------------------------------------------------------
+                     'additionalScores', (
+                         SELECT jsonb_agg(
+                             jsonb_build_object(
+                               'key', question_config->>'key',
+                               'answer', pcpp.meta_data -> (question_config->>'key')
+                             )
+                         )
+                         FROM jsonb_array_elements(
+                                dpm.course_phase_meta_data->'additionalScores'
+                              ) question_config
+                     ),
+                     ----------------------------------------------------------
+                     -- (C) Aggregate Answers from text and multi-select questions
+                     ----------------------------------------------------------
+                     'applicationAnswers', (
+                         SELECT jsonb_agg(answer_obj)
+                         FROM (
+                            -- Text answers
+                            SELECT jsonb_build_object(
+                                'key', qt.access_key,
+                                'answer', to_jsonb(aat.answer),
+                                'order_num', qt.order_num, 
+                                'type', 'text'
+                            ) AS answer_obj
+                            FROM application_question_text qt
+                            JOIN application_answer_text aat
+                              ON aat.application_question_id = qt.id
+                             AND aat.course_phase_participation_id = pcpp.id
+                            WHERE qt.course_phase_id = dpm.phase_id
+                              AND qt.accessible_for_other_phases = true
+                              AND qt.access_key IS NOT NULL
+                              AND qt.access_key <> ''
+                            
+                            UNION ALL
+                            
+                            -- Multi-select answers
+                            SELECT jsonb_build_object(
+                                'key', qm.access_key,
+                                'answer', to_jsonb(aams.answer),
+                                'order_num', qm.order_num, 
+                                'type', 'multiselect'
+                            ) AS answer_obj
+                            FROM application_question_multi_select qm
+                            JOIN application_answer_multi_select aams
+                              ON aams.application_question_id = qm.id
+                             AND aams.course_phase_participation_id = pcpp.id
+                            WHERE qm.course_phase_id = dpm.phase_id
+                              AND qm.accessible_for_other_phases = true
+                              AND qm.access_key IS NOT NULL
+                              AND qm.access_key <> ''
+                         ) answer_union
+                 )
+             ) AS obj
          ) appdata
        ),
        '{}'


### PR DESCRIPTION
This PR changes the applicationAnswers of the Application Phase to be exported as an Array of JSON which provides the key, type (text/multiselect), answer and ordernum. 
With this it is easier to display them in subsequent phases, such as the interview phase. 

It also adjust the course configurator to correctly display this in the imported / exported meta data. 

### Metadata Handling Improvements:
* [`clients/core/src/CourseConfigurator/PhaseNode/components/MetaDataBadges.tsx`](diffhunk://#diff-591a85a69e5fcbf1583086f39870de9a1afa38cd0b834f32b61c8a8a365c3faaL4-R6): Refactored to use new utility functions `getMetaDataStatus` and `renderBadgeTooltipContent` for determining metadata status and rendering tooltip content. [[1]](diffhunk://#diff-591a85a69e5fcbf1583086f39870de9a1afa38cd0b834f32b61c8a8a365c3faaL4-R6) [[2]](diffhunk://#diff-591a85a69e5fcbf1583086f39870de9a1afa38cd0b834f32b61c8a8a365c3faaL20-L66) [[3]](diffhunk://#diff-591a85a69e5fcbf1583086f39870de9a1afa38cd0b834f32b61c8a8a365c3faaL75-R46)
* [`clients/core/src/CourseConfigurator/PhaseNode/components/utils/getBadgeStatus.tsx`](diffhunk://#diff-2ab6fcec39b4881516a0f6070db09ec6843a1ba5b3f85641564073f20987df22R1-R131): Added a new utility function `getMetaDataStatus` to determine the status of metadata items based on provided and expected metadata.
* [`clients/core/src/CourseConfigurator/PhaseNode/components/utils/renderBadgeTooltip.tsx`](diffhunk://#diff-c361c81019d0b0f1a09237c5d44ec59fbe669a52d7e015ac241503d59ee79b8eR1-R49): Added a new utility function `renderBadgeTooltipContent` to render tooltip content based on metadata name.
* [`clients/core/src/CourseConfigurator/PhaseNode/components/utils/renderTooltipList.tsx`](diffhunk://#diff-e6234cfdd518b1e72f6dd66268a6b1c51a2784db85f439bd9cdd8c9a25be300aR1-R27): Added a new utility function `renderTooltipList` to render lists within tooltips.

### Icon Updates:
* [`clients/core/src/CourseConfigurator/PhaseNode/PhaseNode.tsx`](diffhunk://#diff-1d605fdd57a785d29e88b955d474db5a66edaf7977f79638baafd24051baf3cbL6-R6): Updated icons for metadata badges to use `FileInput` and `FileOutput` instead of `ArrowDownToLine` and `ArrowUpFromLine`. [[1]](diffhunk://#diff-1d605fdd57a785d29e88b955d474db5a66edaf7977f79638baafd24051baf3cbL6-R6) [[2]](diffhunk://#diff-1d605fdd57a785d29e88b955d474db5a66edaf7977f79638baafd24051baf3cbL141-R140) [[3]](diffhunk://#diff-1d605fdd57a785d29e88b955d474db5a66edaf7977f79638baafd24051baf3cbL151-R150)

### SQL Query Enhancements:
* [`server/db/query/course_phase_participation.sql`](diffhunk://#diff-1184a1f8fe60badd6aa1cd1d9a23899e4bb14c6d523303dafbd516bd90fec9a2L219-R284): Refactored SQL queries to use `jsonb_build_object` for exporting application scores, additional scores, and application answers.

### Environment Variable Changes:
* [`clients/core/public/env.js`](diffhunk://#diff-b19d427f59ead2c79973e41f7b4ae3556baf46f846ede8334d29a0dcc69150a4L3-R5): Updated environment variable names to remove the `REACT_APP_` prefix.