### PR TITLE
Adjusting course phase participation api

### DIFF
--- a/server/applicationAdministration/service.go
+++ b/server/applicationAdministration/service.go
@@ -489,22 +489,9 @@ func UpdateApplicationAssessment(ctx context.Context, coursePhaseID uuid.UUID, c
 	qtx := ApplicationServiceSingleton.queries.WithTx(tx)
 
 	if assessment.PassStatus != nil || assessment.MetaData.Length() > 0 {
-		var passStatus db.NullPassStatus
-		if assessment.PassStatus != nil {
-			passStatus = db.NullPassStatus{
-				Valid:      true,
-				PassStatus: *assessment.PassStatus,
-			}
-		} else {
-			passStatus = db.NullPassStatus{
-				Valid:      false,
-				PassStatus: "",
-			}
-		}
-
 		err := coursePhaseParticipation.UpdateCoursePhaseParticipation(ctx, qtx, coursePhaseParticipationDTO.UpdateCoursePhaseParticipation{
 			ID:         coursePhaseParticipationID,
-			PassStatus: passStatus,
+			PassStatus: assessment.PassStatus,
 			MetaData:   assessment.MetaData,
 		})
 		if err != nil {

--- a/server/applicationAdministration/service.go
+++ b/server/applicationAdministration/service.go
@@ -490,9 +490,10 @@ func UpdateApplicationAssessment(ctx context.Context, coursePhaseID uuid.UUID, c
 
 	if assessment.PassStatus != nil || assessment.MetaData.Length() > 0 {
 		err := coursePhaseParticipation.UpdateCoursePhaseParticipation(ctx, qtx, coursePhaseParticipationDTO.UpdateCoursePhaseParticipation{
-			ID:         coursePhaseParticipationID,
-			PassStatus: assessment.PassStatus,
-			MetaData:   assessment.MetaData,
+			ID:            coursePhaseParticipationID,
+			PassStatus:    assessment.PassStatus,
+			MetaData:      assessment.MetaData,
+			CoursePhaseID: coursePhaseID,
 		})
 		if err != nil {
 			log.Error(err)

--- a/server/coursePhase/coursePhaseParticipation/coursePhaseParticipationDTO/create_course_phase_participation.go
+++ b/server/coursePhase/coursePhaseParticipation/coursePhaseParticipationDTO/create_course_phase_participation.go
@@ -8,10 +8,10 @@ import (
 )
 
 type CreateCoursePhaseParticipation struct {
-	CourseParticipationID uuid.UUID         `json:"course_participation_id"`
-	CoursePhaseID         uuid.UUID         `json:"course_phase_id"`
-	PassStatus            db.NullPassStatus `json:"pass_status"`
-	MetaData              meta.MetaData     `json:"meta_data"`
+	CourseParticipationID uuid.UUID      `json:"course_participation_id"`
+	CoursePhaseID         uuid.UUID      `json:"course_phase_id"`
+	PassStatus            *db.PassStatus `json:"pass_status"`
+	MetaData              meta.MetaData  `json:"meta_data"`
 }
 
 func (c CreateCoursePhaseParticipation) GetDBModel() (db.CreateCoursePhaseParticipationParams, error) {
@@ -24,7 +24,7 @@ func (c CreateCoursePhaseParticipation) GetDBModel() (db.CreateCoursePhasePartic
 	return db.CreateCoursePhaseParticipationParams{
 		CourseParticipationID: c.CourseParticipationID,
 		CoursePhaseID:         c.CoursePhaseID,
-		PassStatus:            c.PassStatus,
+		PassStatus:            GetPassStatusDBModel(c.PassStatus),
 		MetaData:              metaDataBytes,
 	}, nil
 

--- a/server/coursePhase/coursePhaseParticipation/coursePhaseParticipationDTO/get_cpp_for_cp.go
+++ b/server/coursePhase/coursePhaseParticipation/coursePhaseParticipationDTO/get_cpp_for_cp.go
@@ -9,11 +9,12 @@ import (
 )
 
 type GetAllCPPsForCoursePhase struct {
-	ID           uuid.UUID          `json:"id"`
-	PassStatus   string             `json:"pass_status"`
-	MetaData     meta.MetaData      `json:"meta_data"`
-	PrevMetaData meta.MetaData      `json:"prev_meta_data"`
-	Student      studentDTO.Student `json:"student"`
+	ID                    uuid.UUID          `json:"id"`
+	PassStatus            string             `json:"pass_status"`
+	CourseParticipationID uuid.UUID          `json:"course_participation_id"`
+	MetaData              meta.MetaData      `json:"meta_data"`
+	PrevMetaData          meta.MetaData      `json:"prev_meta_data"`
+	Student               studentDTO.Student `json:"student"`
 }
 
 func GetAllCPPsForCoursePhaseDTOFromDBModel(model db.GetAllCoursePhaseParticipationsForCoursePhaseIncludingPreviousRow) (GetAllCPPsForCoursePhase, error) {
@@ -30,10 +31,11 @@ func GetAllCPPsForCoursePhaseDTOFromDBModel(model db.GetAllCoursePhaseParticipat
 	}
 
 	return GetAllCPPsForCoursePhase{
-		ID:           model.CoursePhaseParticipationID,
-		PassStatus:   GetPassStatusString(model.PassStatus),
-		MetaData:     metaData,
-		PrevMetaData: prevMetaData,
+		ID:                    model.CoursePhaseParticipationID,
+		CourseParticipationID: model.CourseParticipationID,
+		PassStatus:            GetPassStatusString(model.PassStatus),
+		MetaData:              metaData,
+		PrevMetaData:          prevMetaData,
 		Student: studentDTO.GetStudentDTOFromDBModel(db.Student{
 			ID:                   model.StudentID,
 			FirstName:            model.FirstName,

--- a/server/coursePhase/coursePhaseParticipation/coursePhaseParticipationDTO/pass_status.go
+++ b/server/coursePhase/coursePhaseParticipation/coursePhaseParticipationDTO/pass_status.go
@@ -8,3 +8,15 @@ func GetPassStatusString(passStatus db.NullPassStatus) string {
 	}
 	return string(db.PassStatusNotAssessed)
 }
+
+func GetPassStatusDBModel(passStatus *db.PassStatus) db.NullPassStatus {
+	if passStatus == nil {
+		return db.NullPassStatus{
+			Valid: false,
+		}
+	}
+	return db.NullPassStatus{
+		Valid:      true,
+		PassStatus: *passStatus,
+	}
+}

--- a/server/coursePhase/coursePhaseParticipation/coursePhaseParticipationDTO/update_course_phase_participation.go
+++ b/server/coursePhase/coursePhaseParticipation/coursePhaseParticipationDTO/update_course_phase_participation.go
@@ -7,10 +7,18 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+type UpdateCoursePhaseParticipationRequest struct {
+	// we require this as the ID might be empty
+	// CoursePhase ID is in the URL
+	CourseParticipationID uuid.UUID      `json:"course_participation_id"`
+	PassStatus            *db.PassStatus `json:"pass_status"`
+	MetaData              meta.MetaData  `json:"meta_data"`
+}
+
 type UpdateCoursePhaseParticipation struct {
-	ID         uuid.UUID         `json:"id"`
-	PassStatus db.NullPassStatus `json:"passed"`
-	MetaData   meta.MetaData     `json:"meta_data"`
+	ID         uuid.UUID      `json:"id"`
+	PassStatus *db.PassStatus `json:"passed"`
+	MetaData   meta.MetaData  `json:"meta_data"`
 }
 
 func (c UpdateCoursePhaseParticipation) GetDBModel() (db.UpdateCoursePhaseParticipationParams, error) {
@@ -22,8 +30,7 @@ func (c UpdateCoursePhaseParticipation) GetDBModel() (db.UpdateCoursePhasePartic
 
 	return db.UpdateCoursePhaseParticipationParams{
 		ID:         c.ID,
-		PassStatus: c.PassStatus,
+		PassStatus: GetPassStatusDBModel(c.PassStatus),
 		MetaData:   metaDataBytes,
 	}, nil
-
 }

--- a/server/coursePhase/coursePhaseParticipation/coursePhaseParticipationDTO/update_course_phase_participation.go
+++ b/server/coursePhase/coursePhaseParticipation/coursePhaseParticipationDTO/update_course_phase_participation.go
@@ -8,17 +8,19 @@ import (
 )
 
 type UpdateCoursePhaseParticipationRequest struct {
-	// we require this as the ID might be empty
-	// CoursePhase ID is in the URL
+	// for individual updates, the ID is in the url
+	// for batch updates, the ID is in the body
+	ID                    uuid.UUID      `json:"id"`
 	CourseParticipationID uuid.UUID      `json:"course_participation_id"`
 	PassStatus            *db.PassStatus `json:"pass_status"`
 	MetaData              meta.MetaData  `json:"meta_data"`
 }
 
 type UpdateCoursePhaseParticipation struct {
-	ID         uuid.UUID      `json:"id"`
-	PassStatus *db.PassStatus `json:"passed"`
-	MetaData   meta.MetaData  `json:"meta_data"`
+	ID            uuid.UUID      `json:"id"`
+	PassStatus    *db.PassStatus `json:"passed"`
+	MetaData      meta.MetaData  `json:"meta_data"`
+	CoursePhaseID uuid.UUID      `json:"course_phase_id"`
 }
 
 func (c UpdateCoursePhaseParticipation) GetDBModel() (db.UpdateCoursePhaseParticipationParams, error) {
@@ -29,8 +31,9 @@ func (c UpdateCoursePhaseParticipation) GetDBModel() (db.UpdateCoursePhasePartic
 	}
 
 	return db.UpdateCoursePhaseParticipationParams{
-		ID:         c.ID,
-		PassStatus: GetPassStatusDBModel(c.PassStatus),
-		MetaData:   metaDataBytes,
+		ID:            c.ID,
+		PassStatus:    GetPassStatusDBModel(c.PassStatus),
+		MetaData:      metaDataBytes,
+		CoursePhaseID: c.CoursePhaseID,
 	}, nil
 }

--- a/server/coursePhase/coursePhaseParticipation/service.go
+++ b/server/coursePhase/coursePhaseParticipation/service.go
@@ -90,7 +90,7 @@ func UpdateCoursePhaseParticipation(ctx context.Context, transactionQueries *db.
 		return errors.New("failed to create DB model from DTO")
 	}
 
-	err = queries.UpdateCoursePhaseParticipation(ctx, participation)
+	_, err = queries.UpdateCoursePhaseParticipation(ctx, participation)
 	if err != nil {
 		log.Error(err)
 		return errors.New("failed to update course phase participation")

--- a/server/coursePhase/coursePhaseParticipation/service.go
+++ b/server/coursePhase/coursePhaseParticipation/service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"fmt"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -96,6 +97,44 @@ func UpdateCoursePhaseParticipation(ctx context.Context, transactionQueries *db.
 	}
 
 	return nil
+}
+
+func UpdateBatchCoursePhaseParticipation(ctx context.Context, newCoursePhaseParticipations []coursePhaseParticipationDTO.CreateCoursePhaseParticipation, updatedCoursePhaseParticipation []coursePhaseParticipationDTO.UpdateCoursePhaseParticipation) ([]uuid.UUID, error) {
+	tx, err := CoursePhaseParticipationServiceSingleton.conn.Begin(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer tx.Rollback(ctx)
+	qtx := CoursePhaseParticipationServiceSingleton.queries.WithTx(tx)
+
+	updatedIDs := make([]uuid.UUID, 0, len(updatedCoursePhaseParticipation)+len(newCoursePhaseParticipations))
+
+	// Replace for loop by DB batch operation in near future
+	for _, participation := range updatedCoursePhaseParticipation {
+		err := UpdateCoursePhaseParticipation(ctx, qtx, participation)
+		if err != nil {
+			log.Error(err)
+			return nil, errors.New("failed to update course phase participation")
+		}
+		updatedIDs = append(updatedIDs, participation.ID)
+	}
+
+	for _, participation := range newCoursePhaseParticipations {
+		newParticipation, err := CreateCoursePhaseParticipation(ctx, qtx, participation)
+		if err != nil {
+			log.Error(err)
+			return nil, errors.New("failed to create course phase participation")
+		}
+		updatedIDs = append(updatedIDs, newParticipation.ID)
+	}
+
+	// commit if all updates were successful
+	if err := tx.Commit(ctx); err != nil {
+		log.Error(err)
+		return nil, fmt.Errorf("failed to commit transaction: %w", err)
+	}
+
+	return updatedIDs, nil
 }
 
 func CreateIfNotExistingPhaseParticipation(ctx context.Context, transactionQueries *db.Queries, CourseParticipationID uuid.UUID, coursePhaseID uuid.UUID) (coursePhaseParticipationDTO.GetCoursePhaseParticipation, error) {

--- a/server/coursePhase/coursePhaseParticipation/service.go
+++ b/server/coursePhase/coursePhaseParticipation/service.go
@@ -74,6 +74,9 @@ func CreateCoursePhaseParticipation(ctx context.Context, transactionQueries *db.
 	if err != nil {
 		return coursePhaseParticipationDTO.GetCoursePhaseParticipation{}, err
 	}
+	if createdParticipation.ID == uuid.Nil {
+		return coursePhaseParticipationDTO.GetCoursePhaseParticipation{}, errors.New("failed to create course phase participation due to mismatch in CourseParticipationID and CoursePhaseID")
+	}
 
 	return coursePhaseParticipationDTO.GetCoursePhaseParticipationDTOFromDBModel(createdParticipation)
 }

--- a/server/db/query/course_phase_participation.sql
+++ b/server/db/query/course_phase_participation.sql
@@ -45,14 +45,14 @@ WHERE cp.id = $2
   AND cph.id = $3
 RETURNING *;
 
--- name: UpdateCoursePhaseParticipation :exec
+-- name: UpdateCoursePhaseParticipation :one
 UPDATE course_phase_participation
 SET 
     pass_status = COALESCE($2, pass_status),   
     meta_data = meta_data || $3
 WHERE id = $1
 AND course_phase_id = $4
-RETURNING *;
+RETURNING id; -- important to trigger a no rows in result set error if ids mismatch
 
 -- name: GetCoursePhaseParticipationByCourseParticipationAndCoursePhase :one
 SELECT * FROM course_phase_participation

--- a/server/db/query/course_phase_participation.sql
+++ b/server/db/query/course_phase_participation.sql
@@ -28,9 +28,21 @@ WHERE
 SELECT * FROM course_phase_participation
 WHERE course_participation_id = $1;
 
+--- We need to ensure that the course_participation_id and course_phase_id 
+--- belong to the same course.
 -- name: CreateCoursePhaseParticipation :one
-INSERT INTO course_phase_participation (id, course_participation_id, course_phase_id, pass_status, meta_data)
-VALUES ($1, $2, $3, $4, $5)
+INSERT INTO course_phase_participation
+    (id, course_participation_id, course_phase_id, pass_status, meta_data)
+SELECT
+    $1 AS id,
+    $2 AS course_participation_id,
+    $3 AS course_phase_id,
+    $4 AS pass_status,
+    $5 AS meta_data
+FROM course_participation cp
+JOIN course_phase cph ON cp.course_id = cph.course_id
+WHERE cp.id = $2
+  AND cph.id = $3
 RETURNING *;
 
 -- name: UpdateCoursePhaseParticipation :exec

--- a/server/db/query/course_phase_participation.sql
+++ b/server/db/query/course_phase_participation.sql
@@ -50,7 +50,9 @@ UPDATE course_phase_participation
 SET 
     pass_status = COALESCE($2, pass_status),   
     meta_data = meta_data || $3
-WHERE id = $1;
+WHERE id = $1
+AND course_phase_id = $4
+RETURNING *;
 
 -- name: GetCoursePhaseParticipationByCourseParticipationAndCoursePhase :one
 SELECT * FROM course_phase_participation

--- a/server/db/sqlc/course_phase_participation.sql.go
+++ b/server/db/sqlc/course_phase_participation.sql.go
@@ -503,16 +503,24 @@ SET
     pass_status = COALESCE($2, pass_status),   
     meta_data = meta_data || $3
 WHERE id = $1
+AND course_phase_id = $4
+RETURNING id, course_participation_id, course_phase_id, meta_data, pass_status, last_modified
 `
 
 type UpdateCoursePhaseParticipationParams struct {
-	ID         uuid.UUID      `json:"id"`
-	PassStatus NullPassStatus `json:"pass_status"`
-	MetaData   []byte         `json:"meta_data"`
+	ID            uuid.UUID      `json:"id"`
+	PassStatus    NullPassStatus `json:"pass_status"`
+	MetaData      []byte         `json:"meta_data"`
+	CoursePhaseID uuid.UUID      `json:"course_phase_id"`
 }
 
 func (q *Queries) UpdateCoursePhaseParticipation(ctx context.Context, arg UpdateCoursePhaseParticipationParams) error {
-	_, err := q.db.Exec(ctx, updateCoursePhaseParticipation, arg.ID, arg.PassStatus, arg.MetaData)
+	_, err := q.db.Exec(ctx, updateCoursePhaseParticipation,
+		arg.ID,
+		arg.PassStatus,
+		arg.MetaData,
+		arg.CoursePhaseID,
+	)
 	return err
 }
 


### PR DESCRIPTION
The main change is that I introduced the ability to "update" course phase participations with uuid.Nil. This is required if a course phase modifies a course phase participation that does not yet exist. 
This pull request includes several changes to the course phase participation feature, focusing on refactoring the handling of `PassStatus`, adding batch update functionality, and improving error handling and testing. Here are the most important changes:

### Refactoring `PassStatus` Handling:
* Changed `PassStatus` type from `db.NullPassStatus` to `*db.PassStatus` across various DTOs and functions to simplify the code and improve clarity. (`server/coursePhase/coursePhaseParticipation/coursePhaseParticipationDTO/create_course_phase_participation.go` [[1]](diffhunk://#diff-d6ccc74ea4afec86fbe21a033bbb1e9d83971fda7235455f0c8baed4490e6e11L13-R13) [[2]](diffhunk://#diff-d6ccc74ea4afec86fbe21a033bbb1e9d83971fda7235455f0c8baed4490e6e11L27-R27); `server/coursePhase/coursePhaseParticipation/coursePhaseParticipationDTO/update_course_phase_participation.go` [[3]](diffhunk://#diff-13133432ff16ca46fd37c2f48e405f614846e81afc0a01f304facd08a032d872R10-R23) [[4]](diffhunk://#diff-13133432ff16ca46fd37c2f48e405f614846e81afc0a01f304facd08a032d872L25-L28)
* Added a helper function `GetPassStatusDBModel` to convert `*db.PassStatus` to `db.NullPassStatus`. (`server/coursePhase/coursePhaseParticipation/coursePhaseParticipationDTO/pass_status.go` [server/coursePhase/coursePhaseParticipation/coursePhaseParticipationDTO/pass_status.goR11-R22](diffhunk://#diff-ce979de87e2a2f5f830985ae2821a281bb8a11fa64dc6a0b93737b6846f97583R11-R22))

### Batch Update Functionality:
* Introduced batch update functionality for course phase participations, allowing multiple updates in a single request. (`server/coursePhase/coursePhaseParticipation/router.go` [[1]](diffhunk://#diff-e006fa6c63390c7a1756c858de0f2bf6604867db93b45ca7590f4b4497050c23L15-R19) [[2]](diffhunk://#diff-e006fa6c63390c7a1756c858de0f2bf6604867db93b45ca7590f4b4497050c23R83-R186); `server/coursePhase/coursePhaseParticipation/service.go` [[3]](diffhunk://#diff-5d60ffa223d09e93363b194b35fa6f2f6233788082a66d6c0c8f52c2af5afa5aR102-R139)

### Error Handling Improvements:
* Added error handling to ensure that course phase participations are not created with mismatched IDs. (`server/coursePhase/coursePhaseParticipation/service.go` [server/coursePhase/coursePhaseParticipation/service.goR78-R80](diffhunk://#diff-5d60ffa223d09e93363b194b35fa6f2f6233788082a66d6c0c8f52c2af5afa5aR78-R80))
* Improved error messages and logging for better debugging and maintenance. (`server/coursePhase/coursePhaseParticipation/service.go` [server/coursePhase/coursePhaseParticipation/service.goL89-R93](diffhunk://#diff-5d60ffa223d09e93363b194b35fa6f2f6233788082a66d6c0c8f52c2af5afa5aL89-R93))

### Testing Enhancements:
* Added new test cases to cover the creation and updating of course phase participations, including the new batch update functionality. (`server/coursePhase/coursePhaseParticipation/router_test.go` [[1]](diffhunk://#diff-1b70bb189a8580d3d479b350c785921f8cd6856b953c7f11063c0c449a826f94R81-R85) [[2]](diffhunk://#diff-1b70bb189a8580d3d479b350c785921f8cd6856b953c7f11063c0c449a826f94R108-R113) [[3]](diffhunk://#diff-1b70bb189a8580d3d479b350c785921f8cd6856b953c7f11063c0c449a826f94R145-R188); `server/coursePhase/coursePhaseParticipation/service_test.go` [[4]](diffhunk://#diff-0be7ee16b8bb678f94b50bc9dd6f524741d6a54b878624b64f40f840076ab94fR59-R64) [[5]](diffhunk://#diff-0be7ee16b8bb678f94b50bc9dd6f524741d6a54b878624b64f40f840076ab94fR81-R87)

These changes collectively improve the robustness, maintainability, and functionality of the course phase participation feature.