### PR TITLE
change go docker build

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,5 +1,5 @@
-FROM golang:1.23-alpine
-
+# Stage 1: Build
+FROM golang:1.23-alpine AS build
 
 # Install dependencies
 RUN apk add --no-cache curl
@@ -8,23 +8,36 @@ RUN apk add --no-cache curl
 RUN curl -L https://github.com/golang-migrate/migrate/releases/download/v4.18.1/migrate.linux-amd64.tar.gz | tar xvz && \
     mv migrate /usr/local/bin/
 
-# Set the Current Working Directory inside the container
+# Set the working directory
 WORKDIR /app
 
 # Copy go mod and sum files
 COPY go.mod go.sum ./
 
-# Download all dependencies. Dependencies will be cached if the go.mod and go.sum files are not changed
+# Download dependencies
 RUN go mod download
 
-# Copy the source from the current directory to the Working Directory inside the container
+# Copy the source code
 COPY . .
 
 # Build the Go app
 RUN go build -o main .
 
-# Expose port 8080 to the outside world
+# Stage 2: Final (distroless)
+FROM gcr.io/distroless/base-debian11
+
+# Set the working directory
+WORKDIR /app
+
+# Copy the built binary and necessary files from the build stage
+COPY --from=build /app/main /app/main
+COPY --from=build /usr/local/bin/migrate /usr/local/bin/migrate
+COPY --from=build /app/db/migration /app/db/migration
+
+# Expose the application port
 EXPOSE 8080
 
-# Command to run the executable
-CMD ["./main"]
+# Run the application
+CMD ["/app/main"]
+
+


### PR DESCRIPTION
This pull request includes significant changes to the `server/Dockerfile` to improve the build and deployment process. The changes involve restructuring the Dockerfile into a multi-stage build and switching to a distroless base image for the final stage.

Improvements to Dockerfile:

* [`server/Dockerfile`](diffhunk://#diff-7dcfbc368ef61cdb87ff87938d3901a82097fe398633f995dc4ab1cbee761a40L1-R2): Restructured into a multi-stage build by adding a build stage and a final stage. This helps in reducing the final image size and improving security.
* [`server/Dockerfile`](diffhunk://#diff-7dcfbc368ef61cdb87ff87938d3901a82097fe398633f995dc4ab1cbee761a40L11-R43): Changed the base image for the final stage to `gcr.io/distroless/base-debian11` to enhance security by minimizing the attack surface.
* [`server/Dockerfile`](diffhunk://#diff-7dcfbc368ef61cdb87ff87938d3901a82097fe398633f995dc4ab1cbee761a40L11-R43): Simplified comments and improved clarity by renaming steps and removing redundant explanations.
* [`server/Dockerfile`](diffhunk://#diff-7dcfbc368ef61cdb87ff87938d3901a82097fe398633f995dc4ab1cbee761a40L11-R43): Updated the command to run the application to align with the new directory structure and multi-stage build.