### PR TITLE
fixing collapsing placeholders

### DIFF
--- a/clients/shared_library/components/pages/Mailing/components/AvailableMailPlaceholders.tsx
+++ b/clients/shared_library/components/pages/Mailing/components/AvailableMailPlaceholders.tsx
@@ -73,13 +73,11 @@ export const AvailableMailPlaceholders = ({
   }
 
   return (
-    <Collapsible
-      open={isOpen}
-      onOpenChange={setIsOpen}
-      onClick={() => setIsOpen((prev) => !prev)}
-      className='space-y-2 border rounded-md'
-    >
-      <div className='flex items-center justify-between p-4 cursor-pointer'>
+    <Collapsible open={isOpen} onOpenChange={setIsOpen} className='space-y-2 border rounded-md'>
+      <div
+        className='flex items-center justify-between p-4 cursor-pointer'
+        onClick={() => setIsOpen((prev) => !prev)}
+      >
         <div>
           <h3 className='text-sm font-medium'>Available Placeholders</h3>
           <p className='text-xs text-muted-foreground mt-1'>

--- a/clients/shared_library/package.json
+++ b/clients/shared_library/package.json
@@ -30,7 +30,6 @@
         "class-variance-authority": "^0.7.0",
         "cmdk": "1.0.0",
         "date-fns": "^4.1.0",
-        "lucide-react": "^0.469.0",
         "react-day-picker": "8.10.1",
         "react-hook-form": "^7.53.2",
         "recharts": "^2.15.0",


### PR DESCRIPTION
Fixing the issue that the available placeholders collapsed. 

Not the Placeholders only collapse and expand when clicked on the "header" component. This enables to correct copy the placeholders.