### PR TITLE
fixing gzip issue

### DIFF
--- a/clients/core/Dockerfile
+++ b/clients/core/Dockerfile
@@ -14,10 +14,6 @@ COPY --from=core-base /app/core/build /usr/share/nginx/html
 COPY --from=core-base /app/nginx/nginx.conf /etc/nginx/conf.d/default.conf
 
 
-EXPOSE 80
-CMD ["nginx", "-g", "daemon off;"]
-
-
 COPY --from=core-base /app/core/build /usr/share/nginx/html
 COPY --from=core-base /app/nginx/nginx.conf /etc/nginx/conf.d/default.conf
 COPY --from=core-base /app/core/build/env.template.js /usr/share/nginx/html/env.template.js

--- a/clients/nginx/nginx.conf
+++ b/clients/nginx/nginx.conf
@@ -3,6 +3,7 @@ server {
   listen 80;
 
   location / {
+    gzip_static on;
     root   /usr/share/nginx/html;
     index  index.html index.htm;
     try_files $uri $uri/ /index.html;

--- a/clients/yarn.lock
+++ b/clients/yarn.lock
@@ -10220,15 +10220,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lucide-react@npm:^0.469.0":
-  version: 0.469.0
-  resolution: "lucide-react@npm:0.469.0"
-  peerDependencies:
-    react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
-  checksum: 10c0/0ee78d110550579b848a01446a440f733fd17e1bf1850aa01551b61f415e03e5f5ab7f26b56f1c648edc93856177f5476ff9f8f6f5d80e8fe45913d208f49961
-  languageName: node
-  linkType: hard
-
 "make-dir@npm:4.0.0":
   version: 4.0.0
   resolution: "make-dir@npm:4.0.0"
@@ -14216,7 +14207,6 @@ __metadata:
     class-variance-authority: "npm:^0.7.0"
     cmdk: "npm:1.0.0"
     date-fns: "npm:^4.1.0"
-    lucide-react: "npm:^0.469.0"
     react-day-picker: "npm:8.10.1"
     react-hook-form: "npm:^7.53.2"
     recharts: "npm:^2.15.0"


### PR DESCRIPTION
This pull request includes changes to the Dockerfile and Nginx configuration to improve the deployment setup for the core client. The most important changes include removing unnecessary commands from the Dockerfile and enabling gzip compression in the Nginx configuration.

Improvements to Dockerfile:

* [`clients/core/Dockerfile`](diffhunk://#diff-7b9ac8ad183ffda01ce8cd6951d42a770c3619e2aaf2c44d2cd4e60823d8abb5L17-L20): Removed the `EXPOSE` and `CMD` commands as they were redundant in this context.

Enhancements to Nginx configuration:

* [`clients/nginx/nginx.conf`](diffhunk://#diff-f923b01989d64e6b3d84e01cafc15f3561b70eaea607e7d6ef5bbfdcb7da3ec6R6): Enabled `gzip_static` to serve pre-compressed files, which can improve loading times for static assets.