### PR TITLE
adding docs to gh pages workflow

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -3,6 +3,11 @@ name: Sphinx docs to gh-pages
 on:
     pull_request:
         branches: [main]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
     
 jobs:
   build-docs:

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -1,8 +1,8 @@
 name: Sphinx docs to gh-pages
 
 on:
-    pull_request:
-        branches: [main]
+  push:
+    branches: [main]
 
 permissions:
   contents: read

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -1,0 +1,51 @@
+name: Sphinx docs to gh-pages
+
+on:
+    pull_request:
+        branches: [main]
+    
+jobs:
+  build-docs:
+    runs-on: ubuntu-latest
+    
+    permissions:
+      contents: read
+      # Needed to upload the artifact containing the built docs
+      # The 'pages: write' and 'id-token: write' are required for deploying to GitHub Pages
+      pages: write
+      id-token: write
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.13'
+      
+      - name: Install dependencies
+        run: |
+          pip install --upgrade pip
+          pip install -r docs/requirements.txt
+
+      - name: Build Sphinx HTML
+        run: |
+          cd docs
+          make html
+
+      - name: Upload generated HTML as artifact
+        id: deployment
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/_build/html
+
+  deploy-docs:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build-docs
+    steps:
+      - name: Deploy to GitHub Pages
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automatically build and deploy Sphinx documentation to GitHub Pages whenever a pull request is made to the `main` branch. The key changes include setting up the workflow configuration, defining jobs for building and deploying the documentation, and specifying the necessary permissions and steps required for these tasks.

### New GitHub Actions Workflow for Documentation:

* [`.github/workflows/build-docs.yml`](diffhunk://#diff-4fdc48ab490b670c90974725b8e3d399b24c03d6d09563acf8ea87d4113930fbR1-R51): Added a new workflow configuration to build and deploy Sphinx documentation to GitHub Pages. This includes setting up the environment, installing dependencies, building the HTML files, and deploying the generated documentation.