### PR TITLE
Various UI fixes

### DIFF
--- a/clients/core/src/managementConsole/applicationAdministration/pages/ApplicationConfiguration/ApplicationQuestionConfig/ApplicationQuestionConfig.tsx
+++ b/clients/core/src/managementConsole/applicationAdministration/pages/ApplicationConfiguration/ApplicationQuestionConfig/ApplicationQuestionConfig.tsx
@@ -139,7 +139,7 @@ export const ApplicationQuestionConfig = (): JSX.Element => {
   }
 
   return (
-    <div className='space-y-6 max-w-4xl mx-auto'>
+    <div className={`space-y-6 max-w-4xl mx-auto  ${questionsModified ? 'pb-10' : ''}`}>
       <div className='flex justify-between items-center'>
         <h2 className='text-2xl font-semibold'>Application Questions</h2>
         <ApplicationPreview
@@ -151,21 +151,6 @@ export const ApplicationQuestionConfig = (): JSX.Element => {
           applicationQuestions={applicationQuestions}
         />
       </div>
-      {questionsModified && (
-        <SaveChangesAlert
-          message='You have unsaved changes'
-          handleRevert={handleRevertAllQuestions}
-          saveChanges={() =>
-            handleSubmitAllQuestions({
-              questionRefs,
-              fetchedForm,
-              applicationQuestions,
-              setSubmitAttempted,
-              mutateApplicationForm,
-            })
-          }
-        />
-      )}
       {applicationQuestions.length > 0 ? (
         <DragDropContext onDragEnd={onDragEnd}>
           <Droppable droppableId='questions'>
@@ -205,6 +190,22 @@ export const ApplicationQuestionConfig = (): JSX.Element => {
             <p className='text-lg mb-4'>No questions added yet.</p>
           </CardContent>
         </Card>
+      )}
+
+      {questionsModified && (
+        <SaveChangesAlert
+          message='You have unsaved changes'
+          handleRevert={handleRevertAllQuestions}
+          saveChanges={() =>
+            handleSubmitAllQuestions({
+              questionRefs,
+              fetchedForm,
+              applicationQuestions,
+              setSubmitAttempted,
+              mutateApplicationForm,
+            })
+          }
+        />
       )}
     </div>
   )

--- a/clients/core/src/managementConsole/applicationAdministration/pages/ApplicationConfiguration/ApplicationQuestionConfig/FormPages/ApplicationQuestionCard.tsx
+++ b/clients/core/src/managementConsole/applicationAdministration/pages/ApplicationConfiguration/ApplicationQuestionConfig/FormPages/ApplicationQuestionCard.tsx
@@ -60,7 +60,8 @@ export const ApplicationQuestionCard = forwardRef<
   const [isExpanded, setIsExpanded] = useState(isNewQuestion)
   const isMultiSelectType = 'options' in question
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false)
-  const [useRichInput, setUseRichInput] = useState(false)
+  // if a rich text is entered -> start with rich text editor
+  const [useRichInput, setUseRichInput] = useState(question.description?.startsWith('<'))
 
   const status: QuestionStatus = originalQuestion
     ? questionsEqual(question, originalQuestion)

--- a/clients/core/src/managementConsole/applicationAdministration/pages/Mailing/ApplicationMailingSettings.tsx
+++ b/clients/core/src/managementConsole/applicationAdministration/pages/Mailing/ApplicationMailingSettings.tsx
@@ -7,7 +7,10 @@ import { useModifyCoursePhase } from '../../hooks/useModifyCoursePhase'
 import { useToast } from '@/hooks/use-toast'
 import { UpdateCoursePhase } from '@tumaet/prompt-shared-state'
 import { useParams } from 'react-router-dom'
-import { CustomApplicationPlaceHolder } from './components/CustomApplicationPlaceHolder'
+import {
+  applicationMailingPlaceholders,
+  CustomApplicationPlaceHolder,
+} from './components/CustomApplicationPlaceHolder'
 import { EmailTemplateEditor } from '@/components/pages/Mailing/components/MailingEditor'
 import { ManagementPageHeader } from '@/components/ManagementPageHeader'
 import { SettingsCard } from './components/SettingsCard'
@@ -128,6 +131,9 @@ export const ApplicationMailingSettings = () => {
               label='Confirmation'
               subjectHTMLLabel='confirmationMailSubject'
               contentHTMLLabel='confirmationMailContent'
+              placeholders={applicationMailingPlaceholders.map(
+                (placeholder) => placeholder.placeholder,
+              )}
             />
           </TabsContent>
           <TabsContent value='acceptance'>
@@ -138,6 +144,9 @@ export const ApplicationMailingSettings = () => {
               label='Acceptance'
               subjectHTMLLabel='passedMailSubject'
               contentHTMLLabel='passedMailContent'
+              placeholders={applicationMailingPlaceholders.map(
+                (placeholder) => placeholder.placeholder,
+              )}
             />
           </TabsContent>
           <TabsContent value='rejection'>
@@ -148,6 +157,9 @@ export const ApplicationMailingSettings = () => {
               label='Rejection'
               subjectHTMLLabel='failedMailSubject'
               contentHTMLLabel='failedMailContent'
+              placeholders={applicationMailingPlaceholders.map(
+                (placeholder) => placeholder.placeholder,
+              )}
             />
           </TabsContent>
         </Tabs>

--- a/clients/core/src/managementConsole/applicationAdministration/pages/Mailing/components/CustomApplicationPlaceHolder.tsx
+++ b/clients/core/src/managementConsole/applicationAdministration/pages/Mailing/components/CustomApplicationPlaceHolder.tsx
@@ -1,18 +1,26 @@
-import { AvailableMailPlaceholders } from '@/components/pages/Mailing/components/AvailableMailPlaceholders'
+import {
+  AvailableMailPlaceholders,
+  availablePlaceholders,
+} from '@/components/pages/Mailing/components/AvailableMailPlaceholders'
+
+const additionalMailPlacerholders = [
+  {
+    placeholder: '{{applicationEndDate}}',
+    description:
+      'The end date of the the application phase. (Not available for acceptance/rejection mails). ',
+  },
+  {
+    placeholder: 'https://{{applicationURL}}',
+    description:
+      'The direct link to the application form. (Not available for acceptance/rejection mails).',
+  },
+]
+
+export const applicationMailingPlaceholders = [
+  ...availablePlaceholders,
+  ...additionalMailPlacerholders,
+]
 
 export const CustomApplicationPlaceHolder = () => {
-  const additionalPlacerholders = [
-    {
-      placeholder: '{{applicationEndDate}}',
-      description:
-        'The end date of the the application phase. (Not available for acceptance/rejection mails). ',
-    },
-    {
-      placeholder: 'https://{{applicationURL}}',
-      description:
-        'The direct link to the application form. (Not available for acceptance/rejection mails).',
-    },
-  ]
-
-  return <AvailableMailPlaceholders customAdditionalPlaceholders={additionalPlacerholders} />
+  return <AvailableMailPlaceholders customAdditionalPlaceholders={additionalMailPlacerholders} />
 }

--- a/clients/shared_library/components/DatePicker.tsx
+++ b/clients/shared_library/components/DatePicker.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import { format } from 'date-fns'
 import { CalendarIcon } from 'lucide-react'
+import { enGB } from 'date-fns/locale'
 
 import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
@@ -35,7 +36,14 @@ export const DatePicker = ({ date, onSelect }: DatePickerProps): JSX.Element => 
         </Button>
       </PopoverTrigger>
       <PopoverContent className='w-auto p-0'>
-        <Calendar mode='single' selected={date} onSelect={handleSelect} initialFocus />
+        <Calendar
+          mode='single'
+          selected={date}
+          onSelect={handleSelect}
+          defaultMonth={date}
+          initialFocus
+          locale={enGB} // changes week start to monday
+        />
       </PopoverContent>
     </Popover>
   )

--- a/clients/shared_library/components/DateRangePicker.tsx
+++ b/clients/shared_library/components/DateRangePicker.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 import { CalendarIcon } from 'lucide-react'
 import { format } from 'date-fns'
 import { DateRange } from 'react-day-picker'
+import { enGB } from 'date-fns/locale'
 
 import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
@@ -53,6 +54,7 @@ export const DatePickerWithRange: React.FC<DatePickerWithRangeProps> = ({
             selected={date}
             onSelect={setDate}
             numberOfMonths={2}
+            locale={enGB}
           />
         </PopoverContent>
       </Popover>

--- a/clients/shared_library/components/SaveChangesAlert.tsx
+++ b/clients/shared_library/components/SaveChangesAlert.tsx
@@ -1,7 +1,7 @@
 import { AlertCircle } from 'lucide-react'
-import { Alert, AlertDescription, AlertTitle } from './ui/alert'
 import { Button } from './ui/button'
 import { useState } from 'react'
+import { useSidebar } from './ui/sidebar'
 
 interface SaveChangesAlertProps {
   message: string
@@ -18,6 +18,7 @@ export const SaveChangesAlert = ({
 }: SaveChangesAlertProps): JSX.Element => {
   const [isSaving, setIsSaving] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const { state } = useSidebar()
 
   const handleSave = async () => {
     setIsSaving(true)
@@ -33,20 +34,28 @@ export const SaveChangesAlert = ({
   }
 
   return (
-    <Alert variant='default' className='mb-4 border-muted bg-muted/20'>
-      <div className='flex flex-col space-y-2 sm:flex-row sm:items-center sm:justify-between sm:space-y-0'>
+    <div
+      className='fixed bottom-0 right-0 bg-background border-t border-border p-4 z-50 transition-all duration-300 ease-in-out'
+      style={{
+        width:
+          state === 'expanded'
+            ? 'calc(100% - var(--sidebar-width))'
+            : 'calc(100% - var(--sidebar-width-icon))',
+        left: state === 'expanded' ? 'var(--sidebar-width)' : 'var(--sidebar-width-icon)',
+      }}
+    >
+      <div className='max-w-7xl mx-auto flex items-center justify-between'>
         <div className='flex items-center space-x-2'>
-          <AlertCircle className='h-4 w-4 text-red-500' />
-          <AlertTitle className='text-foreground'>{message}</AlertTitle>
+          <AlertCircle className='h-4 w-4 text-yellow-500' />
+          <p className='text-sm font-medium'>{message}</p>
         </div>
-        <div className='flex flex-col space-y-2 sm:flex-row sm:space-y-0 sm:space-x-2'>
+        <div className='flex space-x-2'>
           <Button
             variant='outline'
             size='sm'
             onClick={handleRevert}
             disabled={isSaving}
             aria-label='Revert changes'
-            className='w-full sm:w-auto'
           >
             Revert
           </Button>
@@ -56,19 +65,16 @@ export const SaveChangesAlert = ({
             onClick={handleSave}
             disabled={isSaving}
             aria-label='Save changes'
-            className='w-full sm:w-auto'
           >
             {isSaving ? 'Saving...' : 'Save'}
           </Button>
         </div>
       </div>
-      <AlertDescription className='mt-2'>
-        {error && (
-          <p className='text-sm text-destructive' role='alert'>
-            {error}
-          </p>
-        )}
-      </AlertDescription>
-    </Alert>
+      {error && (
+        <p className='mt-2 text-sm text-destructive text-center' role='alert'>
+          {error}
+        </p>
+      )}
+    </div>
   )
 }

--- a/clients/shared_library/components/minimal-tiptap/components/section/mailingPlaceholders.tsx
+++ b/clients/shared_library/components/minimal-tiptap/components/section/mailingPlaceholders.tsx
@@ -1,0 +1,53 @@
+import * as React from 'react'
+import type { Editor } from '@tiptap/react'
+import type { FormatAction } from '../../types'
+import type { toggleVariants } from '@/components/ui/toggle'
+import type { VariantProps } from 'class-variance-authority'
+import { ListBulletIcon } from '@radix-ui/react-icons'
+import { ToolbarSection } from '../toolbar-section'
+import { MailSearch } from 'lucide-react'
+
+const formatActions = (placeholders: string[]): FormatAction[] => {
+  return placeholders.map((placeholder) => ({
+    label: placeholder,
+    icon: <ListBulletIcon className='size-5' />,
+    action: (editor) => {
+      editor.chain().focus().insertContent(`${placeholder}`).run()
+    },
+    isActive: () => false,
+    canExecute: () => true,
+    shortcuts: [],
+    value: placeholder,
+  }))
+}
+
+interface SectionMailingPlaceholderProps extends VariantProps<typeof toggleVariants> {
+  editor: Editor
+  placeholders: string[]
+}
+
+export const SectionMailingPlaceholders: React.FC<SectionMailingPlaceholderProps> = ({
+  editor,
+  placeholders,
+  size,
+  variant,
+}) => {
+  return (
+    <ToolbarSection
+      editor={editor}
+      actions={formatActions(placeholders)}
+      dropdownIcon={
+        <>
+          <MailSearch className='size-5' />
+        </>
+      }
+      dropdownTooltip='Available Mailing Placeholders'
+      size={size}
+      variant={variant}
+    />
+  )
+}
+
+SectionMailingPlaceholders.displayName = 'MailingPlaceholders'
+
+export default SectionMailingPlaceholders

--- a/clients/shared_library/components/minimal-tiptap/mailing-tiptap.tsx
+++ b/clients/shared_library/components/minimal-tiptap/mailing-tiptap.tsx
@@ -1,0 +1,101 @@
+import * as React from 'react'
+import './styles/index.css'
+
+import type { Content, Editor } from '@tiptap/react'
+import type { UseMinimalTiptapEditorProps } from './hooks/use-minimal-tiptap'
+import { EditorContent } from '@tiptap/react'
+import { Separator } from '@/components/ui/separator'
+import { cn } from '@/lib/utils'
+import { SectionOne } from './components/section/one'
+import { SectionTwo } from './components/section/two'
+import { SectionThree } from './components/section/three'
+import { SectionFour } from './components/section/four'
+import { SectionFive } from './components/section/five'
+import { LinkBubbleMenu } from './components/bubble-menu/link-bubble-menu'
+import { useMinimalTiptapEditor } from './hooks/use-minimal-tiptap'
+import { MeasuredContainer } from './components/measured-container'
+import SectionMailingPlaceholders from './components/section/mailingPlaceholders'
+
+export interface MailingTiptapProps extends Omit<UseMinimalTiptapEditorProps, 'onUpdate'> {
+  value?: Content
+  onChange?: (value: Content) => void
+  className?: string
+  editorContentClassName?: string
+  placeholders: string[]
+}
+
+const MailingToolbar = ({ editor, placeholders }: { editor: Editor; placeholders: string[] }) => (
+  <div className='shrink-0 overflow-x-auto border-b border-border p-2'>
+    <div className='flex w-max items-center gap-px'>
+      <SectionOne editor={editor} activeLevels={[1, 2, 3, 4, 5, 6]} />
+
+      <Separator orientation='vertical' className='mx-2 h-7' />
+
+      <SectionTwo
+        editor={editor}
+        activeActions={['bold', 'italic', 'underline', 'strikethrough', 'code', 'clearFormatting']}
+        mainActionCount={3}
+      />
+
+      <Separator orientation='vertical' className='mx-2 h-7' />
+
+      <SectionThree editor={editor} />
+
+      <Separator orientation='vertical' className='mx-2 h-7' />
+
+      <SectionFour
+        editor={editor}
+        activeActions={['orderedList', 'bulletList']}
+        mainActionCount={0}
+      />
+
+      <Separator orientation='vertical' className='mx-2 h-7' />
+
+      <SectionFive
+        editor={editor}
+        activeActions={['codeBlock', 'blockquote', 'horizontalRule']}
+        mainActionCount={0}
+      />
+      <Separator orientation='vertical' className='mx-2 h-7' />
+
+      <SectionMailingPlaceholders editor={editor} placeholders={placeholders} />
+    </div>
+  </div>
+)
+
+export const MailingTiptapEditor = React.forwardRef<HTMLDivElement, MailingTiptapProps>(
+  ({ value, onChange, className, editorContentClassName, placeholders, ...props }, ref) => {
+    const editor = useMinimalTiptapEditor({
+      value,
+      onUpdate: onChange,
+      ...props,
+    })
+
+    if (!editor) {
+      return null
+    }
+
+    return (
+      <MeasuredContainer
+        as='div'
+        name='editor'
+        ref={ref}
+        className={cn(
+          'flex h-auto min-h-72 w-full flex-col rounded-md border border-input shadow-sm focus-within:border-primary',
+          className,
+        )}
+      >
+        <MailingToolbar editor={editor} placeholders={placeholders} />
+        <EditorContent
+          editor={editor}
+          className={cn('minimal-tiptap-editor', editorContentClassName)}
+        />
+        <LinkBubbleMenu editor={editor} />
+      </MeasuredContainer>
+    )
+  },
+)
+
+MailingTiptapEditor.displayName = 'MailingTiptapEditor'
+
+export default MailingTiptapEditor

--- a/clients/shared_library/components/pages/Mailing/CoursePhaseMailing.tsx
+++ b/clients/shared_library/components/pages/Mailing/CoursePhaseMailing.tsx
@@ -8,7 +8,10 @@ import {
   UpdateCoursePhase,
   CoursePhaseMailingConfigData,
 } from '@tumaet/prompt-shared-state'
-import { AvailableMailPlaceholders } from './components/AvailableMailPlaceholders'
+import {
+  AvailableMailPlaceholders,
+  availablePlaceholders,
+} from './components/AvailableMailPlaceholders'
 import { EmailTemplateEditor } from './components/MailingEditor'
 import { SettingsCard } from './components/SettingsCard'
 import { useGetMailingIsConfigured } from '@/hooks/useGetMailingIsConfigured'
@@ -124,6 +127,7 @@ export const CoursePhaseMailing = ({ coursePhase }: CoursePhaseMailingProps) => 
               label='Passed'
               subjectHTMLLabel='passedMailSubject'
               contentHTMLLabel='passedMailContent'
+              placeholders={availablePlaceholders.map((placeholder) => placeholder.placeholder)}
             />
           </TabsContent>
           <TabsContent value='failed'>
@@ -134,6 +138,7 @@ export const CoursePhaseMailing = ({ coursePhase }: CoursePhaseMailingProps) => 
               label='Failed'
               subjectHTMLLabel='failedMailSubject'
               contentHTMLLabel='failedMailContent'
+              placeholders={availablePlaceholders.map((placeholder) => placeholder.placeholder)}
             />
           </TabsContent>
         </Tabs>

--- a/clients/shared_library/components/pages/Mailing/components/AvailableMailPlaceholders.tsx
+++ b/clients/shared_library/components/pages/Mailing/components/AvailableMailPlaceholders.tsx
@@ -21,7 +21,7 @@ export const availablePlaceholders = [
     description: 'The first name of the student',
   },
   {
-    placeholder: '{{lastName}',
+    placeholder: '{{lastName}}',
     description: 'The last name of the student',
   },
   {

--- a/clients/shared_library/components/pages/Mailing/components/AvailableMailPlaceholders.tsx
+++ b/clients/shared_library/components/pages/Mailing/components/AvailableMailPlaceholders.tsx
@@ -15,61 +15,63 @@ interface AvailableMailPlaceholdersProps {
   customAdditionalPlaceholders?: { placeholder: string; description: string }[]
 }
 
+export const availablePlaceholders = [
+  {
+    placeholder: '{{firstName}}',
+    description: 'The first name of the student',
+  },
+  {
+    placeholder: '{{lastName}',
+    description: 'The last name of the student',
+  },
+  {
+    placeholder: '{{email}}',
+    description: 'The email of the student',
+  },
+  {
+    placeholder: '{{matriculationNumber}}',
+    description: 'The matriculation number of the student. Might be empty',
+  },
+  {
+    placeholder: '{{universityLogin}}',
+    description: `The ${translations.university['login-name']} of the student. Might be empty`,
+  },
+  {
+    placeholder: '{{studyDegree}}',
+    description: 'The study degree of the student',
+  },
+  {
+    placeholder: '{{currentSemester}}',
+    description: 'The current semester of the student',
+  },
+  {
+    placeholder: '{{studyProgram}}',
+    description: 'The study program of the student',
+  },
+
+  {
+    placeholder: '{{courseName}}',
+    description: 'The name of the course',
+  },
+  {
+    placeholder: '{{courseStartDate}}',
+    description: 'The start date of the course',
+  },
+  {
+    placeholder: '{{courseEndDate}}',
+    description: 'The end date of the course',
+  },
+]
+
 export const AvailableMailPlaceholders = ({
   customAdditionalPlaceholders,
 }: AvailableMailPlaceholdersProps) => {
   const [isOpen, setIsOpen] = useState(false)
 
-  const availablePlaceholders = [
-    {
-      placeholder: '{{firstName}}',
-      description: 'The first name of the student',
-    },
-    {
-      placeholder: '{{lastName}',
-      description: 'The last name of the student',
-    },
-    {
-      placeholder: '{{email}}',
-      description: 'The email of the student',
-    },
-    {
-      placeholder: '{{matriculationNumber}}',
-      description: 'The matriculation number of the student. Might be empty',
-    },
-    {
-      placeholder: '{{universityLogin}}',
-      description: `The ${translations.university['login-name']} of the student. Might be empty`,
-    },
-    {
-      placeholder: '{{studyDegree}}',
-      description: 'The study degree of the student',
-    },
-    {
-      placeholder: '{{currentSemester}}',
-      description: 'The current semester of the student',
-    },
-    {
-      placeholder: '{{studyProgram}}',
-      description: 'The study program of the student',
-    },
-
-    {
-      placeholder: '{{courseName}}',
-      description: 'The name of the course',
-    },
-    {
-      placeholder: '{{courseStartDate}}',
-      description: 'The start date of the course',
-    },
-    {
-      placeholder: '{{courseEndDate}}',
-      description: 'The end date of the course',
-    },
-  ]
+  const placeholders = [...availablePlaceholders]
 
   if (customAdditionalPlaceholders) {
-    availablePlaceholders.push(...customAdditionalPlaceholders)
+    placeholders.push(...customAdditionalPlaceholders)
   }
 
   return (
@@ -98,7 +100,7 @@ export const AvailableMailPlaceholders = ({
                 </TableRow>
               </TableHeader>
               <TableBody>
-                {availablePlaceholders.map((placeholder) => (
+                {placeholders.map((placeholder) => (
                   <TableRow key={placeholder.placeholder}>
                     <TableCell className='font-mono text-sm'>{placeholder.placeholder}</TableCell>
                     <TableCell className='text-sm'>{placeholder.description}</TableCell>

--- a/clients/shared_library/components/pages/Mailing/components/MailingEditor.tsx
+++ b/clients/shared_library/components/pages/Mailing/components/MailingEditor.tsx
@@ -1,8 +1,8 @@
-import MinimalTiptapEditor from '@/components/minimal-tiptap/minimal-tiptap'
 import { Label } from '@/components/ui/label'
 import { TooltipProvider } from '@/components/ui/tooltip'
 import { Input } from '@/components/ui/input'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import MailingTiptapEditor from '@/components/minimal-tiptap/mailing-tiptap'
 
 interface EmailTemplateEditorProps {
   subject: string
@@ -11,6 +11,7 @@ interface EmailTemplateEditorProps {
   label: string
   subjectHTMLLabel: string
   contentHTMLLabel: string
+  placeholders: string[]
 }
 
 export const EmailTemplateEditor = ({
@@ -20,6 +21,7 @@ export const EmailTemplateEditor = ({
   label,
   subjectHTMLLabel,
   contentHTMLLabel,
+  placeholders,
 }: EmailTemplateEditorProps): JSX.Element => {
   return (
     <Card>
@@ -40,7 +42,7 @@ export const EmailTemplateEditor = ({
         <div>
           <Label htmlFor={contentHTMLLabel}>{label} E-Mail Template</Label>
           <TooltipProvider>
-            <MinimalTiptapEditor
+            <MailingTiptapEditor
               value={content}
               onChange={(newContent) =>
                 onInputChange({
@@ -54,6 +56,7 @@ export const EmailTemplateEditor = ({
               autofocus={false}
               editable={true}
               editorClassName='focus:outline-none'
+              placeholders={placeholders}
             />
           </TooltipProvider>
         </div>


### PR DESCRIPTION
This PR incorporate the first part of @krusche feedback. 
Disclaimer: This does not yet incorporate all feedback, but the first fixes which I could fix quickly. 

## DatePicker
- The datepicker now opens on the month of the selected date
- The week now starts on Mondays (instead of Sundays)

## Rich-Text Editor
The state of the rich text editor is now remembered. 
So if you reopen a question, where the description has rich text, then the rich text editor is automatically activated. 

## Placeholders in rich text editor
For the Mailing Text Editors, the placeholders are now integrated in the editor. You can select the placeholder and it is automatically entered in the text. 
![Bildschirmfoto 2025-02-02 um 14 59 31](https://github.com/user-attachments/assets/fa9984a5-eb19-4821-967e-363c1b2d28f6)

## Saving of application questions
As first step of the improving the saving button, is now displayed at the bottom of the screen. This improves the UX, as the user does not need to scroll up to save. 
In the next step, the logic will be adjusted to incorporate 'auto-save' to get rid of the save button completely. 

![Bildschirmfoto 2025-02-02 um 15 00 36](https://github.com/user-attachments/assets/bcb11818-dfc2-4327-844d-2d0c470acf81)

