### PR TITLE
Fix Go Testing Pipeline

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -8,6 +8,7 @@ jobs:
   test-server:
     uses: ./.github/workflows/go-tests.yml
   build-and-push-server:
+    needs: test-server
     uses: ./.github/workflows/build-and-push-server.yml
     secrets: inherit
   build-and-push-clients:

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
 
 jobs:
+  test-server:
+    uses: ./.github/workflows/go-tests.yml
+    secrets: inherit
   build-and-push-server:
     uses: ./.github/workflows/build-and-push-server.yml
     secrets: inherit

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -7,7 +7,6 @@ on:
 jobs:
   test-server:
     uses: ./.github/workflows/go-tests.yml
-    secrets: inherit
   build-and-push-server:
     uses: ./.github/workflows/build-and-push-server.yml
     secrets: inherit

--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -26,4 +26,4 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: Go-results-${{ matrix.directory }}
-          path: ${{ matrix.directory }}/TestResults-${{ matrix.directory }}.json
+          path: ./${{ matrix.directory }}/TestResults-${{ matrix.directory }}.json

--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -27,4 +27,4 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: Go-results-${{ matrix.directory }}
-          path: ./${{ matrix.directory }}/TestResults-${{ matrix.directory }}.json
+          path: ${{ matrix.directory }}/TestResults-${{ matrix.directory }}.json

--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install dependencies
         run: cd ${{ matrix.directory }} && go mod download
       - name: Test with Go
-        run:  cd ${{ matrix.directory }} && go test ./... -json > TestResults-${{ matrix.directory }}.json
+        run:  cd ${{ matrix.directory }} && go test -race ./... -json > TestResults-${{ matrix.directory }}.json
       - name: Upload Go test results
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -1,8 +1,7 @@
 name: Go Test
 
 on:
-  pull_request:
-    branches: [main]
+  workflow_dispatch:
 
 jobs:
   test:

--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -1,7 +1,7 @@
 name: Go Test
 
 on:
-  workflow_dispatch:
+  workflow_call:
 
 jobs:
   test:


### PR DESCRIPTION
This pull request includes changes to the GitHub Actions workflows to improve the testing process and ensure better integration between jobs. The most important changes include adding a new test job, modifying the trigger for the Go test workflow, and enhancing the Go test command.

Improvements to Go testing workflow:

* [`.github/workflows/go-tests.yml`](diffhunk://#diff-5a1bcf51eaa62614197dde8c00207b1c6a3c91d08241b0953e600baa7b66f6d7L24-R24): Updated the `go test` command to include the `-race` flag for detecting possible race conditions
* [`.github/workflows/go-tests.yml`](diffhunk://#diff-5a1bcf51eaa62614197dde8c00207b1c6a3c91d08241b0953e600baa7b66f6d7L4-R4): Changed the trigger from `pull_request` to `workflow_call` to allow the workflow to be able to call it from the dev workflow
* [`.github/workflows/dev.yml`](diffhunk://#diff-914da273e1d936250929f1160bdd8be46aa865099502b04b471fe734f6b644ddR8-R11): Added a new `test-server` job that uses the `go-tests.yml` workflow and set the `build-and-push-server` job to depend on the `test-server` job