### PR TITLE
fixing length violation bug

### DIFF
--- a/server/applicationAdministration/validation.go
+++ b/server/applicationAdministration/validation.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgtype"
@@ -278,7 +279,7 @@ func validateTextAnswers(textQuestions []db.ApplicationQuestionText, textAnswers
 		if question.ValidationRegex.String != "" && exists && !regexp.MustCompile(question.ValidationRegex.String).MatchString(answer) {
 			return fmt.Errorf("answer to question %s does not match validation regex", question.ID)
 		}
-		if exists && len(answer) > int(question.AllowedLength.Int32) {
+		if exists && utf8.RuneCountInString(answer) > int(question.AllowedLength.Int32) {
 			return fmt.Errorf("answer to question %s exceeds allowed length of %d", question.ID, question.AllowedLength.Int32)
 		}
 	}


### PR DESCRIPTION
This pull request includes changes to improve the validation of text answers in `server/applicationAdministration/validation.go`. The most important changes include adding a new import and modifying the length validation logic.

Validation improvements:

* [`server/applicationAdministration/validation.go`](diffhunk://#diff-c56132977d814678c48479be94bc9a75c15ade5ba6c736a98d8c7234cb347dc0R9): Added `utf8` package to the import statements to support UTF-8 encoding.
* [`server/applicationAdministration/validation.go`](diffhunk://#diff-c56132977d814678c48479be94bc9a75c15ade5ba6c736a98d8c7234cb347dc0L281-R282): Updated the length validation in `validateTextAnswers` function to use `utf8.RuneCountInString` instead of `len` to correctly count the number of characters in a string, ensuring that multi-byte characters are properly accounted for.