### PR TITLE
Fixing Type Warning

### DIFF
--- a/clients/shared_library/components/minimal-tiptap/hooks/use-throttle.ts
+++ b/clients/shared_library/components/minimal-tiptap/hooks/use-throttle.ts
@@ -5,7 +5,7 @@ export function useThrottle<T extends (...args: any[]) => void>(
   delay: number,
 ): (...args: Parameters<T>) => void {
   const lastRan = useRef(Date.now())
-  const timeoutRef = useRef<NodeJS.Timeout | null>(null)
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   return useCallback(
     (...args: Parameters<T>) => {


### PR DESCRIPTION
Dieser PR sollte die Warning, die ihr bekommen habt 'Namespace 'global.NodeJS' has no exported member 'Timeout'.' fixen. 

Bitte überprüft, ob die Warning bei euch immer noch auftritt. 