### PR TITLE
fixing interview questions times bug to not update correctly

### DIFF
--- a/clients/interview_component/src/interview/components/InterviewQuestionsDialog.tsx
+++ b/clients/interview_component/src/interview/components/InterviewQuestionsDialog.tsx
@@ -33,6 +33,8 @@ export const InterviewQuestionsDialog = () => {
     if (coursePhase && coursePhase.restrictedData?.interviewQuestions) {
       const questions = coursePhase.restrictedData.interviewQuestions as InterviewQuestion[]
       setInterviewQuestions(questions)
+    } else {
+      setInterviewQuestions([])
     }
   }, [coursePhase])
 

--- a/clients/interview_component/src/interview/components/InterviewQuestionsDialog.tsx
+++ b/clients/interview_component/src/interview/components/InterviewQuestionsDialog.tsx
@@ -30,13 +30,12 @@ export const InterviewQuestionsDialog = () => {
   const { mutate } = useUpdateCoursePhaseMetaData()
 
   useEffect(() => {
-    if (coursePhase && coursePhase.restrictedData?.interviewQuestions) {
-      const questions = coursePhase.restrictedData.interviewQuestions as InterviewQuestion[]
+    if (isOpen) {
+      const questions =
+        coursePhase?.restrictedData?.interviewQuestions ?? ([] as InterviewQuestion[])
       setInterviewQuestions(questions)
-    } else {
-      setInterviewQuestions([])
     }
-  }, [coursePhase])
+  }, [isOpen, coursePhase])
 
   const addQuestion = () => {
     if (newQuestion.trim()) {

--- a/clients/interview_component/src/interview/components/InterviewTimesDialog.tsx
+++ b/clients/interview_component/src/interview/components/InterviewTimesDialog.tsx
@@ -38,12 +38,10 @@ export const InterviewTimesDialog = () => {
   }
 
   useEffect(() => {
-    if (coursePhase?.restrictedData?.interviewSlots) {
-      setInterviewSlots(coursePhase.restrictedData.interviewSlots)
-    } else {
-      setInterviewSlots([])
+    if (isOpen) {
+      setInterviewSlots(coursePhase?.restrictedData?.interviewSlots ?? [])
     }
-  }, [coursePhase])
+  }, [isOpen, coursePhase])
 
   const addSlot = () => {
     setInterviewSlots((prevSlots) => {

--- a/clients/interview_component/src/interview/components/InterviewTimesDialog.tsx
+++ b/clients/interview_component/src/interview/components/InterviewTimesDialog.tsx
@@ -40,6 +40,8 @@ export const InterviewTimesDialog = () => {
   useEffect(() => {
     if (coursePhase?.restrictedData?.interviewSlots) {
       setInterviewSlots(coursePhase.restrictedData.interviewSlots)
+    } else {
+      setInterviewSlots([])
     }
   }, [coursePhase])
 


### PR DESCRIPTION
Closing #164 
This pull request includes updates to the `InterviewQuestionsDialog` and `InterviewTimesDialog` components to handle cases where `coursePhase` does not contain restricted data.

Handling empty interview data:

* [`clients/interview_component/src/interview/components/InterviewQuestionsDialog.tsx`](diffhunk://#diff-42656452025da5c289f48a9f199c5c2badae03792552c8859a7a7a245cf92aa2R36-R37): Added a condition to set `interviewQuestions` to an empty array if `coursePhase.restrictedData?.interviewQuestions` is not available.
* [`clients/interview_component/src/interview/components/InterviewTimesDialog.tsx`](diffhunk://#diff-d51402b0f33f1a1d7b9609bf3da11c780154b478e933a8aa732d750b4d2e7525R43-R44): Added a condition to set `interviewSlots` to an empty array if `coursePhase.restrictedData?.interviewSlots` is not available.