### PR TITLE
Changing the application sorting behavior

### DIFF
--- a/clients/core/src/managementConsole/applicationAdministration/pages/ApplicationAssessment/ApplicationsAssessment.tsx
+++ b/clients/core/src/managementConsole/applicationAdministration/pages/ApplicationAssessment/ApplicationsAssessment.tsx
@@ -20,7 +20,7 @@ import {
   TableRow,
 } from '@/components/ui/table'
 import { columns } from './components/table/columns'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { Input } from '@/components/ui/input'
 import { SearchIcon } from 'lucide-react'
 import { FilterMenu } from './components/table/filtering/FilterMenu'
@@ -39,7 +39,10 @@ import { useDeleteApplications } from './hooks/useDeleteApplications'
 
 export const ApplicationsAssessment = (): JSX.Element => {
   const { additionalScores, participations } = useApplicationStore()
-  const [sorting, setSorting] = useState<SortingState>([{ id: 'lastName', desc: false }])
+  const [sorting, setSorting] = useState<SortingState>([
+    { id: 'passStatus', desc: false },
+    { id: 'lastName', desc: false },
+  ])
   const [globalFilter, setGlobalFilter] = useState<string>('')
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([])
   const [columnVisibility, setColumnVisibility] = useState<VisibilityState>({ gender: false })
@@ -91,6 +94,18 @@ export const ApplicationsAssessment = (): JSX.Element => {
       columnVisibility,
     },
   })
+
+  // when sorting for status, this adds sorting by last name
+  useEffect(() => {
+    if (
+      sorting.find((sort) => sort.id === 'passStatus') &&
+      !sorting.find((sort) => sort.id === 'lastName')
+    ) {
+      setSorting((prev) => {
+        return [...prev, { id: 'lastName', desc: false }]
+      })
+    }
+  }, [sorting])
 
   return (
     <div id='table-view' className='relative flex flex-col space-y-6'>


### PR DESCRIPTION
@Mtze please check if this matches your expectations for the sorting behavior

This PR changes how the sorting of applications behave:
- on default it is sorted by pass status
- On selecting pass status sorting, the applications are additionally sorted by last name (so de-facto clicking pass status sorting also activates last name sorting)