### PR TITLE
displaying row count

### DIFF
--- a/clients/core/src/managementConsole/applicationAdministration/pages/ApplicationAssessment/ApplicationsAssessment.tsx
+++ b/clients/core/src/managementConsole/applicationAdministration/pages/ApplicationAssessment/ApplicationsAssessment.tsx
@@ -92,8 +92,11 @@ export const ApplicationsAssessment = (): JSX.Element => {
     },
   })
 
+  const filteredRowsCount = table.getFilteredRowModel().rows.length
+  const totalRowsCount = participations?.length ?? 0
+
   return (
-    <div id='table-view' className='relative flex flex-col space-y-6'>
+    <div id='table-view' className='relative flex flex-col'>
       <ManagementPageHeader>Applications Overview</ManagementPageHeader>
       <div className='space-y-4'>
         <div className='flex flex-col sm:flex-row items-start sm:items-center space-y-2 sm:space-y-0 sm:space-x-4'>
@@ -129,6 +132,10 @@ export const ApplicationsAssessment = (): JSX.Element => {
         <div className='flex flex-wrap gap-2'>
           <FilterBadges filters={columnFilters} onRemoveFilter={setColumnFilters} />
         </div>
+      </div>
+
+      <div className='text-sm text-muted-foreground mb-2 mt-4'>
+        Showing {filteredRowsCount} of {totalRowsCount} applications
       </div>
 
       <div className='rounded-md border' style={{ width: `${tableWidth + 50}px` }}>


### PR DESCRIPTION
 
<img width="1098" alt="Bildschirmfoto 2025-02-13 um 18 37 44" src="https://github.com/user-attachments/assets/d9439989-3ac8-4346-bcf4-3f7508540dc1" />

This pull request includes changes to the `ApplicationsAssessment` component in the `clients/core/src/managementConsole/applicationAdministration/pages/ApplicationAssessment/ApplicationsAssessment.tsx` file. The primary changes involve adding functionality to display the count of filtered and total rows in the applications table.

Enhancements to the ApplicationsAssessment component:

* Added variables `filteredRowsCount` and `totalRowsCount` to calculate the number of filtered and total rows in the applications table.
* Included a new div element to display the text "Showing {filteredRowsCount} of {totalRowsCount} applications" above the table.