### PR TITLE
Cache Invalidation After Redeployment

### DIFF
--- a/clients/core/webpack.config.ts
+++ b/clients/core/webpack.config.ts
@@ -88,9 +88,10 @@ const config: (env: Record<string, string>) => container.Configuration = (env) =
       new ModuleFederationPlugin({
         name: 'core',
         remotes: {
-          template_component: `template_component@${templateURL}/remoteEntry.js`,
-          interview_component: `interview_component@${interviewURL}/remoteEntry.js`,
-          matching_component: `matching_component@${matchingURL}/remoteEntry.js`,
+          // The date will be resolved at buildtime and will force a cache reload after redeployment
+          template_component: `template_component@${templateURL}/remoteEntry.js?${Date.now()}`,
+          interview_component: `interview_component@${interviewURL}/remoteEntry.js?${Date.now()}`,
+          matching_component: `matching_component@${matchingURL}/remoteEntry.js?${Date.now()}`,
         },
         shared: {
           react: { singleton: true, requiredVersion: deps.react },


### PR DESCRIPTION
# Problem
After redeployment, the loading of the remote course phase often failed and worked after cache invalidation. 
This issue can be simply explained. All 'usual' scripts use a 'content-hash' in the script name. If, on redeployment, the content changes, so does the the hash and hence due to the different name, the browser is forced to reload. 

However, the remoteEntry.js of each independently loaded module must have a constant name. The browser caches the script and then the loading fails (as the referred scripts in this file are outdated). 

# Solution
We add the built time timestamp as query parameter to the remote parameter. This results to re-loaded this file after reach re-deployment which is exactly the behavior we want. 

(As the timestamp is set at build time it is only re-laoded once after redeployment)