### PR TITLE
Row Un-Selection on Visibility Change

### DIFF
--- a/clients/core/src/managementConsole/applicationAdministration/pages/ApplicationAssessment/ApplicationsAssessment.tsx
+++ b/clients/core/src/managementConsole/applicationAdministration/pages/ApplicationAssessment/ApplicationsAssessment.tsx
@@ -46,6 +46,7 @@ export const ApplicationsAssessment = (): JSX.Element => {
   const [globalFilter, setGlobalFilter] = useState<string>('')
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([])
   const [columnVisibility, setColumnVisibility] = useState<VisibilityState>({ gender: false })
+  const [rowSelection, setRowSelection] = useState({})
 
   const [dialogOpen, setDialogOpen] = useState(false)
   const [selectedCourseParticipationID, setSelectedCourseParticipationID] = useState<
@@ -94,8 +95,26 @@ export const ApplicationsAssessment = (): JSX.Element => {
       globalFilter,
       columnFilters,
       columnVisibility,
+      rowSelection,
     },
+    onRowSelectionChange: setRowSelection,
   })
+
+  // When the filters change, update the row selection so that only visible rows remain selected
+  useEffect(() => {
+    // Get the ids of rows that are visible after filtering
+    const visibleRowIDs = new Set(table.getFilteredRowModel().rows.map((row) => row.id))
+    // Update rowSelection to only keep selections for visible rows
+    setRowSelection((prevSelection) => {
+      const newSelection = { ...prevSelection }
+      Object.keys(newSelection).forEach((id) => {
+        if (!visibleRowIDs.has(id)) {
+          delete newSelection[id]
+        }
+      })
+      return newSelection
+    })
+  }, [columnFilters, globalFilter, table])
 
   // when sorting for status, this adds sorting by last name
   useEffect(() => {


### PR DESCRIPTION
This pull request includes changes to the `ApplicationsAssessment` component in the `ApplicationAssessment` page to enhance row selection functionality. The most important changes include adding state management for row selection and ensuring that row selections are updated based on visible rows after filtering.

Enhancements to row selection functionality:

* [`clients/core/src/managementConsole/applicationAdministration/pages/ApplicationAssessment/ApplicationsAssessment.tsx`](diffhunk://#diff-2d7fb4960385917b4eb5a986c6c26f565b8e8d72944e29c56d824370956eb068R49): Added `rowSelection` state using `useState` to manage row selections.
* [`clients/core/src/managementConsole/applicationAdministration/pages/ApplicationAssessment/ApplicationsAssessment.tsx`](diffhunk://#diff-2d7fb4960385917b4eb5a986c6c26f565b8e8d72944e29c56d824370956eb068R98-R118): Included `rowSelection` in the table options and added `onRowSelectionChange` to update the state when row selections change.
* [`clients/core/src/managementConsole/applicationAdministration/pages/ApplicationAssessment/ApplicationsAssessment.tsx`](diffhunk://#diff-2d7fb4960385917b4eb5a986c6c26f565b8e8d72944e29c56d824370956eb068R98-R118): Implemented a `useEffect` hook to update `rowSelection` so that only visible rows remain selected after filters change.