### PR TITLE
Application Phase Auto Accept

### DIFF
--- a/clients/core/src/managementConsole/applicationAdministration/hooks/useParseApplicationMetaData.ts
+++ b/clients/core/src/managementConsole/applicationAdministration/hooks/useParseApplicationMetaData.ts
@@ -12,12 +12,14 @@ export const useParseApplicationMetaData = (
       const applicationStartDate = coursePhase?.restrictedData?.['applicationStartDate']
       const applicationEndDate = coursePhase?.restrictedData?.['applicationEndDate']
       const universityLoginAvailable = coursePhase?.restrictedData?.['universityLoginAvailable']
+      const autoAccept = coursePhase?.restrictedData?.['autoAccept']
 
       const parsedMetaData: ApplicationMetaData = {
         applicationStartDate: applicationStartDate ? new Date(applicationStartDate) : undefined,
         applicationEndDate: applicationEndDate ? new Date(applicationEndDate) : undefined,
         externalStudentsAllowed: externalStudentsAllowed ? externalStudentsAllowed : false,
         universityLoginAvailable: universityLoginAvailable ? universityLoginAvailable : false,
+        autoAccept: autoAccept ? autoAccept : false,
       }
       setApplicationMetaData(parsedMetaData)
     }

--- a/clients/core/src/managementConsole/applicationAdministration/interfaces/applicationMetaData.ts
+++ b/clients/core/src/managementConsole/applicationAdministration/interfaces/applicationMetaData.ts
@@ -3,4 +3,5 @@ export type ApplicationMetaData = {
   applicationEndDate?: Date
   externalStudentsAllowed?: boolean
   universityLoginAvailable?: boolean
+  autoAccept?: boolean
 }

--- a/clients/core/src/managementConsole/applicationAdministration/pages/ApplicationConfiguration/components/ApplicationConfigDialog.tsx
+++ b/clients/core/src/managementConsole/applicationAdministration/pages/ApplicationConfiguration/components/ApplicationConfigDialog.tsx
@@ -48,6 +48,7 @@ export function ApplicationConfigDialog({
   const [endTime, setEndTime] = useState('23:59')
   const [externalStudentsAllowed, setExternalStudentsAllowed] = useState(false)
   const [universityLoginAvailable, setUniversityLoginAvailable] = useState(false)
+  const [autoAccept, setAutoAccept] = useState(false)
   const [dateError, setDateError] = useState<string | null>(null)
 
   const timeZone = 'Europe/Berlin'
@@ -71,6 +72,7 @@ export function ApplicationConfigDialog({
           ? getTimeString(new Date(initialData.applicationEndDate))
           : '23:59',
       )
+      setAutoAccept(initialData?.autoAccept ?? false)
       setExternalStudentsAllowed(initialData?.externalStudentsAllowed ?? false)
       setUniversityLoginAvailable(initialData?.universityLoginAvailable ?? false)
       setDateError(null)
@@ -130,6 +132,7 @@ export function ApplicationConfigDialog({
         applicationEndDate: endDateTime ? formatISO(toZonedTime(endDateTime, timeZone)) : undefined,
         externalStudentsAllowed,
         universityLoginAvailable,
+        autoAccept,
       },
     }
 
@@ -249,6 +252,20 @@ export function ApplicationConfigDialog({
                     <p className='text-sm text-muted-foreground'>
                       This option is to allow external students to apply without login and
                       matriculation number.
+                    </p>
+                  </div>
+                </div>
+
+                {/* Auto Accept */}
+                <div className='grid grid-cols-4 items-start gap-4'>
+                  <Label htmlFor='autoAccept' className='text-right pt-2'>
+                    Auto Accept
+                  </Label>
+                  <div className='col-span-3 flex flex-col gap-2'>
+                    <Switch id='autoAccept' checked={autoAccept} onCheckedChange={setAutoAccept} />
+                    <p className='text-sm text-muted-foreground'>
+                      This option will automatically accept all applications without any manual
+                      review.
                     </p>
                   </div>
                 </div>

--- a/servers/core/applicationAdministration/service.go
+++ b/servers/core/applicationAdministration/service.go
@@ -225,7 +225,6 @@ func PostApplicationExtern(ctx context.Context, coursePhaseID uuid.UUID, applica
 		}
 	} else {
 		// create student
-		// FIX THIS!!!!
 		studentObj, err = student.CreateStudent(ctx, qtx, application.Student)
 		if err != nil {
 			log.Error(err)
@@ -273,6 +272,16 @@ func PostApplicationExtern(ctx context.Context, coursePhaseID uuid.UUID, applica
 			log.Error(err)
 			return uuid.Nil, errors.New("could save the application answers")
 		}
+	}
+
+	// Set Application To Passed if feature is turned on
+	err = qtx.AcceptApplicationIfAutoAccept(ctx, db.AcceptApplicationIfAutoAcceptParams{
+		CoursePhaseID:         coursePhaseID,
+		CourseParticipationID: cPhaseParticipation.CourseParticipationID,
+	})
+	if err != nil {
+		log.Error(err)
+		return uuid.Nil, errors.New("could not save the application answers")
 	}
 
 	err = qtx.StoreApplicationAnswerUpdateTimestamp(ctx, db.StoreApplicationAnswerUpdateTimestampParams{
@@ -419,6 +428,16 @@ func PostApplicationAuthenticatedStudent(ctx context.Context, coursePhaseID uuid
 			return uuid.Nil, errors.New("could not save the application answers")
 		}
 
+	}
+
+	// 4. Set Application To Passed if feature is turned on
+	err = qtx.AcceptApplicationIfAutoAccept(ctx, db.AcceptApplicationIfAutoAcceptParams{
+		CoursePhaseID:         coursePhaseID,
+		CourseParticipationID: cPhaseParticipation.CourseParticipationID,
+	})
+	if err != nil {
+		log.Error(err)
+		return uuid.Nil, errors.New("could not save the application answers")
 	}
 
 	err = qtx.StoreApplicationAnswerUpdateTimestamp(ctx, db.StoreApplicationAnswerUpdateTimestampParams{

--- a/servers/core/db/query/application.sql
+++ b/servers/core/db/query/application.sql
@@ -287,3 +287,14 @@ SET restricted_data = jsonb_set(
 )
 WHERE course_phase_id = $1
  AND course_participation_id = $2;
+
+-- name: AcceptApplicationIfAutoAccept :exec
+UPDATE course_phase_participation
+SET pass_status = 'passed'
+WHERE course_phase_id = $1
+  AND course_participation_id = $2
+  AND (
+    SELECT (restricted_data->>'autoAccept')::boolean
+    FROM course_phase
+    WHERE id = $1
+  ) = true;


### PR DESCRIPTION
This pull request introduces a new feature to automatically accept applications based on a new `autoAccept` flag in the application metadata. 

### Frontend Changes:

* [`clients/core/src/managementConsole/applicationAdministration/hooks/useParseApplicationMetaData.ts`](diffhunk://#diff-76c9277b4524a08a4a7b80737a8d11f059422431fefc0b7225fbf78bcc2162f1R15-R22): Added `autoAccept` to the parsed metadata.
* [`clients/core/src/managementConsole/applicationAdministration/interfaces/applicationMetaData.ts`](diffhunk://#diff-497ce44d1f334eac9e28617ff19a451acbc924f8ff124bfe337166d9a018660dR6): Added `autoAccept` to the `ApplicationMetaData` type.
* `clients/core/src/managementConsole/applicationAdministration/pages/ApplicationConfiguration/components/ApplicationConfigDialog.tsx`: 
  * Initialized `autoAccept` state.
  * Set `autoAccept` state from initial data.
  * Included `autoAccept` in the configuration object.
  * Added a switch for the `autoAccept` option in the UI.

### Backend Changes:

* `servers/core/applicationAdministration/service.go`: 
  * Implemented logic to automatically accept applications if the `autoAccept` flag is set. [[1]](diffhunk://#diff-ba4521f75157423a687aca9bc2318f7860f3ddf7ab505ff06ef8434fc31cccbcR277-R286) [[2]](diffhunk://#diff-ba4521f75157423a687aca9bc2318f7860f3ddf7ab505ff06ef8434fc31cccbcR433-R442)
* [`servers/core/db/query/application.sql`](diffhunk://#diff-f2ad3b288240f2d7c349acdfd799ded3492174b2cce1362211416e831f9722cfR290-R300): Added SQL query to update the application status based on the `autoAccept` flag.
* [`servers/core/db/sqlc/application.sql.go`](diffhunk://#diff-27f6f584513a1401959f4caf4a6c42aeb7594136e68655d37bc78f41d05ef4a4R15-R36): Added a new method to execute the `autoAccept` query.