### PR TITLE
`Core`: Add Mail Subject Sanitization

### DIFF
--- a/clients/shared_library/components/pages/Mailing/components/MailingEditor.tsx
+++ b/clients/shared_library/components/pages/Mailing/components/MailingEditor.tsx
@@ -28,7 +28,7 @@ export const EmailTemplateEditor = ({
   const [subjectWarning, setSubjectWarning] = useState('')
 
   // Regular expression to allow only ASCII characters
-  const asciiOnlyRegex = /^[\x00-\x7F]*$/
+  const asciiOnlyRegex = /^[\x20-\x7F]*$/
 
   // Custom onChange handler for subject input
   const handleSubjectChange = (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/clients/shared_library/components/pages/Mailing/components/MailingEditor.tsx
+++ b/clients/shared_library/components/pages/Mailing/components/MailingEditor.tsx
@@ -1,3 +1,4 @@
+import React, { useState } from 'react'
 import { Label } from '@/components/ui/label'
 import { TooltipProvider } from '@/components/ui/tooltip'
 import { Input } from '@/components/ui/input'
@@ -23,6 +24,25 @@ export const EmailTemplateEditor = ({
   contentHTMLLabel,
   placeholders,
 }: EmailTemplateEditorProps): JSX.Element => {
+  // Local state to hold warning message
+  const [subjectWarning, setSubjectWarning] = useState('')
+
+  // Regular expression to allow only ASCII characters
+  const asciiOnlyRegex = /^[\x00-\x7F]*$/
+
+  // Custom onChange handler for subject input
+  const handleSubjectChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value
+    if (!asciiOnlyRegex.test(value)) {
+      // Set a warning message and do not propagate the change
+      setSubjectWarning('Warning: Only ASCII characters are allowed.')
+      return
+    }
+    // Clear any warning and propagate the valid change
+    setSubjectWarning('')
+    onInputChange(e)
+  }
+
   return (
     <Card>
       <CardHeader>
@@ -35,9 +55,10 @@ export const EmailTemplateEditor = ({
             type='text'
             name={subjectHTMLLabel}
             value={subject}
-            onChange={(e) => onInputChange(e)}
+            onChange={handleSubjectChange}
             className='w-full mt-1'
           />
+          {subjectWarning && <p className='text-red-500 text-sm mt-1'>{subjectWarning}</p>}
         </div>
         <div>
           <Label htmlFor={contentHTMLLabel}>{label} E-Mail Template</Label>
@@ -52,7 +73,7 @@ export const EmailTemplateEditor = ({
               className='w-full mt-1'
               editorContentClassName='p-4'
               output='html'
-              placeholder={`Type your email here...`}
+              placeholder='Type your email here...'
               autofocus={false}
               editable={true}
               editorClassName='focus:outline-none'


### PR DESCRIPTION
This pull request includes updates to the `EmailTemplateEditor` component in the `MailingEditor.tsx` file to improve input validation and user feedback. The most important changes include the addition of a local state for a warning message, a regular expression to enforce ASCII-only input in the Mail Subject. 

We need to enforce ASCII-only input in the Subject to prevent the following mailing error:
` SMTPUTF8 is required, but was not offered by host mailrelay.in.tum.de[131.159.254.10]`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The subject input field now validates entries to allow only standard characters, displaying a warning when unsupported characters are detected.
- **Style**
  - Refined placeholder text in the editor for enhanced clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->