### PR TITLE
`Intro Course`: Add Seat Plan Assignment Student Display

### DIFF
--- a/clients/intro_course_developer_component/src/introCourse/IntroCoursePage.tsx
+++ b/clients/intro_course_developer_component/src/introCourse/IntroCoursePage.tsx
@@ -3,18 +3,16 @@ import { ManagementPageHeader } from '@/components/ManagementPageHeader'
 import { IntroCourseStep } from './components/IntroCourseStep'
 import { useIntroCourseStore } from './zustand/useIntroCourseStore'
 import { DeveloperProfilePage } from './pages/DeveloperProfile/DeveloperProfilePage'
+import { StudentSeatAssignmentDisplay } from './pages/StudentSeatAssignmentDisplay/StudentSeatAssignmentDisplay'
 
 export const IntroCoursePage = (): JSX.Element => {
   // TODO: replace with actual state management
-  const { developerProfile } = useIntroCourseStore()
+  const { developerProfile, seatAssignment } = useIntroCourseStore()
   const [stepsOpen, setStepsOpen] = useState(() => {
-    if (developerProfile === undefined) return [true, false, false]
-    return [false, true, false]
+    if (developerProfile === undefined) return [true, false]
+    if (developerProfile !== undefined && seatAssignment !== undefined) return [false, true]
+    return [false, false]
   })
-
-  // These will be replaced by actual data fetching
-  const [infrastructureComplete, setInfrastructureComplete] = useState(false)
-  const [seatAssignment, setSeatAssignment] = useState(false)
 
   return (
     <div>
@@ -32,31 +30,19 @@ export const IntroCoursePage = (): JSX.Element => {
           isOpen={stepsOpen[0]}
           onToggle={() => setStepsOpen((prev) => [!prev[0], prev[1], prev[2]])}
         >
-          <DeveloperProfilePage onContinue={() => setStepsOpen((prev) => [false, true, prev[2]])} />
+          <DeveloperProfilePage onContinue={() => setStepsOpen((prev) => [false, prev[1]])} />
         </IntroCourseStep>
 
         <IntroCourseStep
           number={2}
-          title='Pre-Intro Course Infrastructure Setup'
-          description='Make sure to complete this checklist before the start of the intro course.'
-          isCompleted={infrastructureComplete}
-          isDisabled={developerProfile === undefined}
-          isOpen={stepsOpen[1]}
-          onToggle={() => setStepsOpen((prev) => [prev[0], !prev[1], prev[2]])}
-        >
-          Here will the be infrastructure setup list.
-        </IntroCourseStep>
-
-        <IntroCourseStep
-          number={3}
           title={`Seat Assignment ${seatAssignment ? '' : '(Available Soon)'}`}
           description='Below you will find the seat assignment for the intro course.'
-          isCompleted={seatAssignment}
-          isDisabled={!infrastructureComplete}
-          isOpen={stepsOpen[2]}
-          onToggle={() => setStepsOpen((prev) => [prev[0], prev[1], !prev[2]])}
+          isCompleted={false}
+          isDisabled={seatAssignment === undefined}
+          isOpen={stepsOpen[1]}
+          onToggle={() => setStepsOpen((prev) => [prev[0], !prev[1]])}
         >
-          Here will be the seat assignment.
+          <StudentSeatAssignmentDisplay />
         </IntroCourseStep>
       </div>
     </div>

--- a/clients/intro_course_developer_component/src/introCourse/network/queries/getOwnSeatPlanAssignment.ts
+++ b/clients/intro_course_developer_component/src/introCourse/network/queries/getOwnSeatPlanAssignment.ts
@@ -1,4 +1,4 @@
-import { SeatAssignment } from 'src/introCourse/pages/SeatAssignment/interfaces/SeatAssignment'
+import { SeatAssignment } from '../../pages/SeatAssignment/interfaces/SeatAssignment'
 import { introCourseAxiosInstance } from '../introCourseServerConfig'
 
 export const getOwnSeatPlanAssignment = async (coursePhaseID: string): Promise<SeatAssignment> => {

--- a/clients/intro_course_developer_component/src/introCourse/network/queries/getOwnSeatPlanAssignment.ts
+++ b/clients/intro_course_developer_component/src/introCourse/network/queries/getOwnSeatPlanAssignment.ts
@@ -1,0 +1,15 @@
+import { SeatAssignment } from 'src/introCourse/pages/SeatAssignment/interfaces/SeatAssignment'
+import { introCourseAxiosInstance } from '../introCourseServerConfig'
+
+export const getOwnSeatPlanAssignment = async (coursePhaseID: string): Promise<SeatAssignment> => {
+  try {
+    return (
+      await introCourseAxiosInstance.get(
+        `intro-course/api/course_phase/${coursePhaseID}/seat_plan/own-assignment`,
+      )
+    ).data
+  } catch (err) {
+    console.error(err)
+    throw err
+  }
+}

--- a/clients/intro_course_developer_component/src/introCourse/pages/SeatAssignment/components/SeatMacAssigner.tsx
+++ b/clients/intro_course_developer_component/src/introCourse/pages/SeatAssignment/components/SeatMacAssigner.tsx
@@ -99,7 +99,7 @@ export const SeatMacAssigner = ({ existingSeats }: SeatMacAssignerProps) => {
             <CardDescription>Assign Mac devices to seats and provide device IDs</CardDescription>
           </div>
           <div className='flex items-center gap-2'>
-            <div className='flex items-center text-blue-600 bg-blue-50 px-3 py-1.5 rounded-md'>
+            <div className='flex items-center px-3 py-1.5 rounded-md'>
               <Laptop className='h-5 w-5 mr-2' />
               <span className='text-sm font-medium'>{macCount} Macs Assigned</span>
             </div>

--- a/clients/intro_course_developer_component/src/introCourse/pages/SeatAssignment/components/SeatStudentAssigner/SeatStudentAssigner.tsx
+++ b/clients/intro_course_developer_component/src/introCourse/pages/SeatAssignment/components/SeatStudentAssigner/SeatStudentAssigner.tsx
@@ -83,7 +83,7 @@ export const SeatStudentAssigner = ({
             </CardDescription>
           </div>
           <div className='flex items-center gap-2'>
-            <div className='flex items-center text-purple-600 bg-purple-50 px-3 py-1.5 rounded-md'>
+            <div className='flex items-center text-purple-600 px-3 py-1.5 rounded-md'>
               <Users className='h-5 w-5 mr-2' />
               <span className='text-sm font-medium'>
                 {assignedStudents} of {totalStudents} Students Assigned

--- a/clients/intro_course_developer_component/src/introCourse/pages/SeatAssignment/components/SeatStudentAssigner/SeatStudentAssigner.tsx
+++ b/clients/intro_course_developer_component/src/introCourse/pages/SeatAssignment/components/SeatStudentAssigner/SeatStudentAssigner.tsx
@@ -161,7 +161,7 @@ export const SeatStudentAssigner = ({
                     .sort((a, b) => a.seatName.localeCompare(b.seatName))
                     .map((seat) => {
                       const student = developerWithProfiles.find(
-                        (dev) => dev.participation.student.id === seat.assignedStudent,
+                        (dev) => dev.participation.courseParticipationID === seat.assignedStudent,
                       )
                       return (
                         <TableRow key={seat.seatName}>

--- a/clients/intro_course_developer_component/src/introCourse/pages/SeatAssignment/components/SeatTutorAssigner/SeatTutorAssigner.tsx
+++ b/clients/intro_course_developer_component/src/introCourse/pages/SeatAssignment/components/SeatTutorAssigner/SeatTutorAssigner.tsx
@@ -81,7 +81,7 @@ export const SeatTutorAssigner = ({
             <CardDescription>Assign tutors to seats for student supervision</CardDescription>
           </div>
           <div className='flex items-center gap-2'>
-            <div className='flex items-center text-purple-600 bg-purple-50 px-3 py-1.5 rounded-md'>
+            <div className='flex items-center text-purple-600 px-3 py-1.5 rounded-md'>
               <UserCheck className='h-5 w-5 mr-2' />
               <span className='text-sm font-medium'>
                 {assignedSeatsCount} of {totalRequiredSeats} Required Seats Assigned

--- a/clients/intro_course_developer_component/src/introCourse/pages/SeatAssignment/hooks/useAssignStudents.tsx
+++ b/clients/intro_course_developer_component/src/introCourse/pages/SeatAssignment/hooks/useAssignStudents.tsx
@@ -71,7 +71,8 @@ export const useAssignStudents = (
         const seatName = shuffledSeatsWithMacs[index].seatName
         const seatIndex = updatedSeats.findIndex((s) => s.seatName === seatName)
         if (seatIndex !== -1) {
-          updatedSeats[seatIndex].assignedStudent = student.participation.student.id ?? null
+          updatedSeats[seatIndex].assignedStudent =
+            student.participation.courseParticipationID ?? null
         }
       }
     })
@@ -86,7 +87,8 @@ export const useAssignStudents = (
         const seatName = allRemainingSeats[index].seatName
         const seatIndex = updatedSeats.findIndex((s) => s.seatName === seatName)
         if (seatIndex !== -1) {
-          updatedSeats[seatIndex].assignedStudent = student.participation.student.id ?? null
+          updatedSeats[seatIndex].assignedStudent =
+            student.participation.courseParticipationID ?? null
         }
       }
     })

--- a/clients/intro_course_developer_component/src/introCourse/pages/SeatAssignment/hooks/useDownloadAssignment.tsx
+++ b/clients/intro_course_developer_component/src/introCourse/pages/SeatAssignment/hooks/useDownloadAssignment.tsx
@@ -21,10 +21,10 @@ export const useDownloadAssignment = (
   }
 
   return useCallback(() => {
-    const getStudentName = (studentId: string | null) => {
-      if (!studentId) return 'Unassigned'
+    const getStudentName = (courseParticipationID: string | null) => {
+      if (!courseParticipationID) return 'Unassigned'
       const student = developerWithProfiles.find(
-        (dev) => dev.participation.student.id === studentId,
+        (dev) => dev.participation.courseParticipationID === courseParticipationID,
       )
       return student
         ? `${student.participation.student.firstName} ${student.participation.student.lastName}`

--- a/clients/intro_course_developer_component/src/introCourse/pages/SeatAssignment/interfaces/SeatAssignment.ts
+++ b/clients/intro_course_developer_component/src/introCourse/pages/SeatAssignment/interfaces/SeatAssignment.ts
@@ -1,0 +1,9 @@
+export type SeatAssignment = {
+  seatName: string
+  hasMac: boolean
+  deviceID: string
+  studentCourseParticipationID: string
+  tutorFirstName: string
+  tutorLastName: string
+  tutorEmail: string
+}

--- a/clients/intro_course_developer_component/src/introCourse/pages/StudentSeatAssignmentDisplay/StudentSeatAssignmentDisplay.tsx
+++ b/clients/intro_course_developer_component/src/introCourse/pages/StudentSeatAssignmentDisplay/StudentSeatAssignmentDisplay.tsx
@@ -1,0 +1,7 @@
+export const StudentSeatAssignmentDisplay = (): JSX.Element => {
+  return (
+    <div>
+      <h1>Student Seat Assignment Display</h1>
+    </div>
+  )
+}

--- a/clients/intro_course_developer_component/src/introCourse/pages/StudentSeatAssignmentDisplay/StudentSeatAssignmentDisplay.tsx
+++ b/clients/intro_course_developer_component/src/introCourse/pages/StudentSeatAssignmentDisplay/StudentSeatAssignmentDisplay.tsx
@@ -1,7 +1,76 @@
+import { useIntroCourseStore } from '../../zustand/useIntroCourseStore'
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
+import { Monitor, User } from 'lucide-react'
+import { getGravatarUrl } from '@/lib/getGravatarUrl'
+import { Badge } from '@/components/ui/badge'
+
+export type SeatAssignment = {
+  seatName: string
+  hasMac: boolean
+  deviceID: string
+  studentCourseParticipationID: string
+  tutorFirstName: string
+  tutorLastName: string
+  tutorEmail: string
+}
+
 export const StudentSeatAssignmentDisplay = (): JSX.Element => {
+  const { seatAssignment } = useIntroCourseStore()
+
+  if (!seatAssignment) {
+    return (
+      <div className='text-center py-6 bg-muted/30 rounded-lg'>
+        <User className='h-12 w-12 mx-auto text-muted-foreground mb-2' />
+        <h3 className='text-lg font-medium mb-2'>No Seat Assigned</h3>
+        <p className='text-muted-foreground max-w-md mx-auto'>
+          You haven&apos;t been assigned a seat yet. Please check back later.
+        </p>
+      </div>
+    )
+  }
+
+  const { seatName, hasMac, deviceID, tutorFirstName, tutorLastName, tutorEmail } = seatAssignment
+  const tutorFullName = `${tutorFirstName} ${tutorLastName}`
+  const tutorInitial = tutorFirstName.charAt(0)
+
   return (
-    <div>
-      <h1>Student Seat Assignment Display</h1>
+    <div className='grid grid-cols-1 md:grid-cols-2 gap-4'>
+      {/* Seat Information Card */}
+      <section className='p-4 bg-muted/20 rounded-lg shadow'>
+        <div className='flex items-center gap-2 mb-3'>
+          <Monitor className='h-5 w-5 text-primary' />
+          <h2 className='text-lg font-medium'>Seat Information</h2>
+        </div>
+        <div>
+          <p className='text-sm text-muted-foreground'>Assigned Seat</p>
+          <p className='text-xl font-semibold'>{seatName}</p>
+        </div>
+        <div className='mt-4'>
+          <p className='text-sm text-muted-foreground'>Device Type</p>
+          <div className='flex items-center gap-2 mt-1'>
+            <Badge className='outline'>{hasMac ? 'Chair Mac' : 'Own MacBook'}</Badge>
+            {deviceID && <span className='text-sm'>ID: {deviceID}</span>}
+          </div>
+        </div>
+      </section>
+
+      {/* Tutor Information Card */}
+      <section className='p-4 bg-muted/20 rounded-lg shadow'>
+        <div className='flex items-center gap-2 mb-3'>
+          <User className='h-5 w-5 text-primary' />
+          <h2 className='text-lg font-medium'>Your Tutor</h2>
+        </div>
+        <div className='flex items-center gap-4'>
+          <Avatar className='h-16 w-16 border-2 border-background shadow-sm'>
+            <AvatarImage src={getGravatarUrl(tutorEmail)} alt={`${tutorFullName}'s avatar`} />
+            <AvatarFallback className='text-lg font-bold'>{tutorInitial}</AvatarFallback>
+          </Avatar>
+          <div>
+            <p className='font-semibold text-lg'>{tutorFullName}</p>
+            <p className='text-sm text-muted-foreground'>{tutorEmail}</p>
+          </div>
+        </div>
+      </section>
     </div>
   )
 }

--- a/clients/intro_course_developer_component/src/introCourse/zustand/useIntroCourseStore.tsx
+++ b/clients/intro_course_developer_component/src/introCourse/zustand/useIntroCourseStore.tsx
@@ -1,10 +1,12 @@
 import { create } from 'zustand'
 import { DeveloperProfile } from '../interfaces/DeveloperProfile'
 import { CoursePhaseParticipationWithStudent } from '@tumaet/prompt-shared-state'
+import { SeatAssignment } from '../pages/SeatAssignment/interfaces/SeatAssignment'
 
 interface IntroCourseStoreState {
   developerProfile?: DeveloperProfile
   coursePhaseParticipation?: CoursePhaseParticipationWithStudent
+  seatAssignment?: SeatAssignment
 }
 
 interface IntroCourseStoreAction {
@@ -12,12 +14,16 @@ interface IntroCourseStoreAction {
   setCoursePhaseParticipation: (
     coursePhaseParticipation: CoursePhaseParticipationWithStudent,
   ) => void
+  setSeatAssignment: (seatAssignment?: SeatAssignment) => void
 }
 
 export const useIntroCourseStore = create<IntroCourseStoreState & IntroCourseStoreAction>(
   (set) => ({
     developerProfile: undefined,
+    coursePhaseParticipation: undefined,
+    seatAssignment: undefined,
     setDeveloperProfile: (developerProfile) => set({ developerProfile }),
     setCoursePhaseParticipation: (coursePhaseParticipation) => set({ coursePhaseParticipation }),
+    setSeatAssignment: (seatAssignment) => set({ seatAssignment }),
   }),
 )

--- a/servers/intro_course/db/query/seat.sql
+++ b/servers/intro_course/db/query/seat.sql
@@ -21,3 +21,10 @@ WHERE course_phase_id = $1
 -- name: DeleteSeatPlan :exec
 DELETE FROM seat
 WHERE course_phase_id = $1;
+
+-- name: GetOwnSeatAssignment :one
+SELECT s.seat_name, s.has_mac, s.device_id, s.assigned_student, t.first_name as tutor_first_name, t.last_name as tutor_last_name, t.email as tutor_email
+FROM seat s
+JOIN tutor t ON s.course_phase_id = t.course_phase_id AND s.assigned_tutor = t.id
+WHERE s.course_phase_id = $1
+  AND s.assigned_student = $2;

--- a/servers/intro_course/seatPlan/router.go
+++ b/servers/intro_course/seatPlan/router.go
@@ -23,6 +23,8 @@ func setupSeatPlanRouter(router *gin.RouterGroup, authMiddleware func(allowedRol
 
 	seatPlanRouter.GET("", authMiddleware(keycloakTokenVerifier.PromptAdmin, keycloakTokenVerifier.CourseLecturer), getSeatPlan)
 
+	seatPlanRouter.GET("/own-assignment", authMiddleware(keycloakTokenVerifier.CourseStudent), getOwnSeatAssignment)
+
 }
 
 func createSeatPlan(c *gin.Context) {
@@ -110,6 +112,31 @@ func deleteSeatPlan(c *gin.Context) {
 	}
 
 	c.Status(http.StatusOK)
+}
+
+func getOwnSeatAssignment(c *gin.Context) {
+	coursePhaseID, err := uuid.Parse(c.Param("coursePhaseID"))
+	if err != nil {
+		log.Error("Error parsing coursePhaseID: ", err)
+		handleError(c, http.StatusBadRequest, err)
+		return
+	}
+
+	courseParticipationID, ok := c.Get("courseParticipationID")
+	if !ok {
+		log.Error("Error getting courseParticipationID from context")
+		handleError(c, http.StatusInternalServerError, err)
+		return
+	}
+
+	seatAssignment, err := GetOwnSeatAssignment(c, coursePhaseID, courseParticipationID.(uuid.UUID))
+
+	if err != nil {
+		handleError(c, http.StatusInternalServerError, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, seatAssignment)
 }
 
 func handleError(c *gin.Context, statusCode int, err error) {

--- a/servers/intro_course/seatPlan/router.go
+++ b/servers/intro_course/seatPlan/router.go
@@ -125,7 +125,7 @@ func getOwnSeatAssignment(c *gin.Context) {
 	courseParticipationID, ok := c.Get("courseParticipationID")
 	if !ok {
 		log.Error("Error getting courseParticipationID from context")
-		handleError(c, http.StatusInternalServerError, err)
+		handleError(c, http.StatusInternalServerError, errors.New("error getting courseParticipationID from context"))
 		return
 	}
 

--- a/servers/intro_course/seatPlan/seatPlanDTO/ownSeatAssignment.go
+++ b/servers/intro_course/seatPlan/seatPlanDTO/ownSeatAssignment.go
@@ -1,0 +1,28 @@
+package seatPlanDTO
+
+import (
+	"github.com/jackc/pgx/v5/pgtype"
+	db "github.com/ls1intum/prompt2/servers/intro_course/db/sqlc"
+)
+
+type SeatAssignment struct {
+	SeatName                     string      `json:"seatName"`
+	HasMac                       bool        `json:"hasMac"`
+	DeviceID                     pgtype.Text `json:"deviceID"`
+	StudentCourseParticipationID pgtype.UUID `json:"studentCourseParticipationID"`
+	TutorFirstName               string      `json:"tutorFirstName"`
+	TutorLastName                string      `json:"tutorLastName"`
+	TutorEmail                   string      `json:"tutorEmail"`
+}
+
+func GetSeatAssignmentDTOFromDBModel(seatAssignment db.GetOwnSeatAssignmentRow) SeatAssignment {
+	return SeatAssignment{
+		SeatName:                     seatAssignment.SeatName,
+		HasMac:                       seatAssignment.HasMac,
+		DeviceID:                     seatAssignment.DeviceID,
+		StudentCourseParticipationID: seatAssignment.AssignedStudent,
+		TutorFirstName:               seatAssignment.TutorFirstName,
+		TutorLastName:                seatAssignment.TutorLastName,
+		TutorEmail:                   seatAssignment.TutorEmail,
+	}
+}


### PR DESCRIPTION
Added a display for the students to see the assigned seat, device and tutor. 

<img width="2078" alt="Bildschirmfoto 2025-03-19 um 14 33 20" src="https://github.com/user-attachments/assets/da545350-83a3-4626-96e2-42ce1b39bd10" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced the Intro Course experience to include seat assignment, allowing students to view personalized seat details.
	- Introduced a dedicated display that presents seat information alongside device and tutor details.
	- Upgraded backend support with new endpoints and data retrieval methods to ensure accurate and timely seat assignment information for students.

- **Bug Fixes**
	- Improved error handling for seat assignment data retrieval.

- **Style**
	- Adjusted visual styling in multiple components for a cleaner presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->