### PR TITLE
`Core`: Inter-Phase Communication Endpoint for Phase Data Retrieval

### DIFF
--- a/servers/core/coursePhase/coursePhaseDTO/get_course_phase_prev_data.go
+++ b/servers/core/coursePhase/coursePhaseDTO/get_course_phase_prev_data.go
@@ -16,7 +16,7 @@ func GetPrevCoursePhaseDataDTO(prevCoreData []byte, resolutions []db.GetPrevCour
 		return PrevCoursePhaseData{}, err
 	}
 
-	resolutionDTOs := []CoursePhaseResolution{}
+	resolutionDTOs := make([]CoursePhaseResolution, 0, len(resolutions))
 	for _, resolution := range resolutions {
 		resolutionDTOs = append(resolutionDTOs, GetResolutionDTOFromDBModel(resolution))
 	}

--- a/servers/core/coursePhase/coursePhaseDTO/get_course_phase_prev_data.go
+++ b/servers/core/coursePhase/coursePhaseDTO/get_course_phase_prev_data.go
@@ -1,0 +1,28 @@
+package coursePhaseDTO
+
+import (
+	db "github.com/niclasheun/prompt2.0/db/sqlc"
+	"github.com/niclasheun/prompt2.0/meta"
+)
+
+type PrevCoursePhaseData struct {
+	PrevData    meta.MetaData           `json:"prevData"`
+	Resolutions []CoursePhaseResolution `json:"resolutions"`
+}
+
+func GetPrevCoursePhaseDataDTO(prevCoreData []byte, resolutions []db.GetPrevCoursePhaseDataResolutionRow) (PrevCoursePhaseData, error) {
+	prevData, err := meta.GetMetaDataDTOFromDBModel(prevCoreData)
+	if err != nil {
+		return PrevCoursePhaseData{}, err
+	}
+
+	resolutionDTOs := []CoursePhaseResolution{}
+	for _, resolution := range resolutions {
+		resolutionDTOs = append(resolutionDTOs, GetResolutionDTOFromDBModel(resolution))
+	}
+
+	return PrevCoursePhaseData{
+		PrevData:    prevData,
+		Resolutions: resolutionDTOs,
+	}, nil
+}

--- a/servers/core/coursePhase/coursePhaseDTO/prev_course_phase_resolution.go
+++ b/servers/core/coursePhase/coursePhaseDTO/prev_course_phase_resolution.go
@@ -1,0 +1,22 @@
+package coursePhaseDTO
+
+import (
+	"github.com/google/uuid"
+	db "github.com/niclasheun/prompt2.0/db/sqlc"
+)
+
+type CoursePhaseResolution struct {
+	DtoName       string    `json:"dtoName"`
+	BaseURL       string    `json:"baseURL"`
+	EndpointPath  string    `json:"endpointPath"`
+	CoursePhaseID uuid.UUID `json:"coursePhaseID"`
+}
+
+func GetResolutionDTOFromDBModel(model db.GetPrevCoursePhaseDataResolutionRow) CoursePhaseResolution {
+	return CoursePhaseResolution{
+		DtoName:       model.DtoName,
+		BaseURL:       model.BaseUrl,
+		EndpointPath:  model.EndpointPath,
+		CoursePhaseID: model.FromCoursePhaseID,
+	}
+}

--- a/servers/core/coursePhase/service.go
+++ b/servers/core/coursePhase/service.go
@@ -83,7 +83,9 @@ func GetPrevPhaseDataByCoursePhaseID(ctx context.Context, coursePhaseID uuid.UUI
 
 	prevCoursePhaseDataDTO, err := coursePhaseDTO.GetPrevCoursePhaseDataDTO(dataFromCore, resolutions)
 	if err != nil {
-		log.Error("failed to create DTO: ", err)
+		log.WithFields(log.Fields{
+			"coursePhaseID": coursePhaseID,
+		}).Error("failed to create previous course phase data DTO: ", err)
 		return coursePhaseDTO.PrevCoursePhaseData{}, err
 	}
 

--- a/servers/core/coursePhase/service.go
+++ b/servers/core/coursePhase/service.go
@@ -69,3 +69,23 @@ func CheckCoursePhasesBelongToCourse(ctx context.Context, courseId uuid.UUID, co
 
 	return ok, nil
 }
+
+func GetPrevPhaseDataByCoursePhaseID(ctx context.Context, coursePhaseID uuid.UUID) (coursePhaseDTO.PrevCoursePhaseData, error) {
+	dataFromCore, err := CoursePhaseServiceSingleton.queries.GetPrevCoursePhaseDataFromCore(ctx, coursePhaseID)
+	if err != nil {
+		return coursePhaseDTO.PrevCoursePhaseData{}, err
+	}
+
+	resolutions, err := CoursePhaseServiceSingleton.queries.GetPrevCoursePhaseDataResolution(ctx, coursePhaseID)
+	if err != nil {
+		return coursePhaseDTO.PrevCoursePhaseData{}, err
+	}
+
+	prevCoursePhaseDataDTO, err := coursePhaseDTO.GetPrevCoursePhaseDataDTO(dataFromCore, resolutions)
+	if err != nil {
+		log.Error("failed to create DTO: ", err)
+		return coursePhaseDTO.PrevCoursePhaseData{}, err
+	}
+
+	return prevCoursePhaseDataDTO, nil
+}


### PR DESCRIPTION
Adding the endpoint for retrieving the previous data for a given course-phase-id. 
Similar to the participation data, this retrieves the data of the 'purple' connections in the course phase editor.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new endpoint that lets authorized users retrieve previous course phase details in a clear, structured JSON format.
  - Improved access control and error handling ensure reliable, real-time retrieval of relevant course data.
  - Enhancements to underlying data management provide a more robust view of past course phase information.
  - New data structures and queries facilitate the retrieval of previous course phase data and resolutions.

- **Bug Fixes**
  - Refined data selection criteria in existing queries for improved accuracy.

- **Tests**
  - Added tests to validate the functionality of retrieving previous phase data based on course phase ID.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->