### PR TITLE
`General`: Add release_tag input to build workflows in prod.yml

### DIFF
--- a/.github/workflows/build-and-push-clients.yml
+++ b/.github/workflows/build-and-push-clients.yml
@@ -63,8 +63,9 @@ jobs:
       image-name: ghcr.io/ls1intum/prompt2/prompt-clients-core
       docker-file: clients/core/Dockerfile # Defaults to Dockerfile
       docker-context: ./clients/core
+      tags: ${{ inputs.release_tag }}
       build-args: |
-        "IMAGE_TAG=${{ inputs.release_tag || needs.clients-base.outputs.image_tag }}"
+        "IMAGE_TAG=${{ needs.clients-base.outputs.image_tag }}"
         "CORE_HOST=${{ vars.CORE_HOST }}"
         "KEYCLOAK_HOST=${{ vars.KEYCLOAK_HOST }}"
         "KEYCLOAK_REALM_NAME=${{ vars.KEYCLOAK_REALM_NAME }}"
@@ -77,8 +78,9 @@ jobs:
       image-name: ghcr.io/ls1intum/prompt2/prompt-clients-template-component
       docker-file: clients/template_component/Dockerfile # Defaults to Dockerfile
       docker-context: ./clients/template_component
+      tags: ${{ inputs.release_tag }}
       build-args: |
-        "IMAGE_TAG=${{ inputs.release_tag || needs.clients-base.outputs.image_tag }}"
+        "IMAGE_TAG=${{ needs.clients-base.outputs.image_tag }}"
         "CORE_HOST=${{ vars.CORE_HOST }}"
     secrets: inherit
 
@@ -89,8 +91,9 @@ jobs:
       image-name: ghcr.io/ls1intum/prompt2/prompt-clients-interview-component
       docker-file: clients/interview_component/Dockerfile # Defaults to Dockerfile
       docker-context: ./clients/interview_component
+      tags: ${{ inputs.release_tag }}
       build-args: |
-        "IMAGE_TAG=${{ inputs.release_tag || needs.clients-base.outputs.image_tag }}"
+        "IMAGE_TAG=${{ needs.clients-base.outputs.image_tag }}"
         "CORE_HOST=${{ vars.CORE_HOST }}"
     secrets: inherit
 
@@ -101,8 +104,9 @@ jobs:
       image-name: ghcr.io/ls1intum/prompt2/prompt-clients-matching-component
       docker-file: clients/matching_component/Dockerfile # Defaults to Dockerfile
       docker-context: ./clients/matching_component
+      tags: ${{ inputs.release_tag }}
       build-args: |
-        "IMAGE_TAG=${{ inputs.release_tag || needs.clients-base.outputs.image_tag }}"
+        "IMAGE_TAG=${{ needs.clients-base.outputs.image_tag }}"
         "CORE_HOST=${{ vars.CORE_HOST }}"
     secrets: inherit
 
@@ -113,8 +117,9 @@ jobs:
       image-name: ghcr.io/ls1intum/prompt2/prompt-clients-intro-course-developer-component
       docker-file: clients/intro_course_developer_component/Dockerfile # Defaults to Dockerfile
       docker-context: ./clients/intro_course_developer_component
+      tags: ${{ inputs.release_tag }}
       build-args: |
-        "IMAGE_TAG=${{ inputs.release_tag || needs.clients-base.outputs.image_tag }}"
+        "IMAGE_TAG=${{ needs.clients-base.outputs.image_tag }}"
         "CORE_HOST=${{ vars.CORE_HOST }}"
     secrets: inherit
 
@@ -125,8 +130,9 @@ jobs:
       image-name: ghcr.io/ls1intum/prompt2/prompt-clients-intro-course-tutor-component
       docker-file: clients/intro_course_tutor_component/Dockerfile # Defaults to Dockerfile
       docker-context: ./clients/intro_course_tutor_component
+      tags: ${{ inputs.release_tag }}
       build-args: |
-        "IMAGE_TAG=${{ inputs.release_tag || needs.clients-base.outputs.image_tag }}"
+        "IMAGE_TAG=${{ needs.clients-base.outputs.image_tag }}"
         "CORE_HOST=${{ vars.CORE_HOST }}"
     secrets: inherit
 
@@ -137,8 +143,9 @@ jobs:
       image-name: ghcr.io/ls1intum/prompt2/prompt-clients-assessment-component
       docker-file: clients/assessment_component/Dockerfile # Defaults to Dockerfile
       docker-context: ./clients/assessment_component
+      tags: ${{ inputs.release_tag }}
       build-args: |
-        "IMAGE_TAG=${{ inputs.release_tag || needs.clients-base.outputs.image_tag }}"
+        "IMAGE_TAG=${{ needs.clients-base.outputs.image_tag }}"
         "CORE_HOST=${{ vars.CORE_HOST }}"
     secrets: inherit
 
@@ -149,19 +156,21 @@ jobs:
       image-name: ghcr.io/ls1intum/prompt2/prompt-clients-devops-challenge-component
       docker-file: clients/devops_challenge_component/Dockerfile # Defaults to Dockerfile
       docker-context: ./clients/devops_challenge_component
+      tags: ${{ inputs.release_tag }}
       build-args: |
-        "IMAGE_TAG=${{ inputs.release_tag || needs.clients-base.outputs.image_tag }}"
+        "IMAGE_TAG=${{ needs.clients-base.outputs.image_tag }}"
         "CORE_HOST=${{ vars.CORE_HOST }}"
     secrets: inherit
 
   team-allocation:
-      needs: clients-base
-      uses: ls1intum/.github/.github/workflows/build-and-push-docker-image.yml@v1.0.0
-      with:
-        image-name: ghcr.io/ls1intum/prompt2/prompt-clients-team-allocation-component
-        docker-file: clients/team_allocation_component/Dockerfile # Defaults to Dockerfile
-        docker-context: ./clients/team_allocation_component
-        build-args: |
-          "IMAGE_TAG=${{ needs.clients-base.outputs.image_tag }}"
-          "CORE_HOST=${{ vars.CORE_HOST }}"
-      secrets: inherit
+    needs: clients-base
+    uses: ls1intum/.github/.github/workflows/build-and-push-docker-image.yml@v1.0.0
+    with:
+      image-name: ghcr.io/ls1intum/prompt2/prompt-clients-team-allocation-component
+      docker-file: clients/team_allocation_component/Dockerfile # Defaults to Dockerfile
+      docker-context: ./clients/team_allocation_component
+      tags: ${{ inputs.release_tag }}
+      build-args: |
+        "IMAGE_TAG=${{ needs.clients-base.outputs.image_tag }}"
+        "CORE_HOST=${{ vars.CORE_HOST }}"
+    secrets: inherit

--- a/.github/workflows/build-and-push-clients.yml
+++ b/.github/workflows/build-and-push-clients.yml
@@ -41,7 +41,7 @@ on:
 
 jobs:
   clients-base:
-    uses: ls1intum/.github/.github/workflows/build-and-push-docker-image.yml@v1.0.0
+    uses: ls1intum/.github/.github/workflows/build-and-push-docker-image.yml@v1.1.0
     with:
       image-name: ghcr.io/ls1intum/prompt2/prompt-clients-base
       docker-file: clients/Dockerfile # Defaults to Dockerfile
@@ -58,7 +58,7 @@ jobs:
 
   core:
     needs: clients-base
-    uses: ls1intum/.github/.github/workflows/build-and-push-docker-image.yml@v1.0.0
+    uses: ls1intum/.github/.github/workflows/build-and-push-docker-image.yml@v1.1.0
     with:
       image-name: ghcr.io/ls1intum/prompt2/prompt-clients-core
       docker-file: clients/core/Dockerfile # Defaults to Dockerfile
@@ -73,7 +73,7 @@ jobs:
 
   template:
     needs: clients-base
-    uses: ls1intum/.github/.github/workflows/build-and-push-docker-image.yml@v1.0.0
+    uses: ls1intum/.github/.github/workflows/build-and-push-docker-image.yml@v1.1.0
     with:
       image-name: ghcr.io/ls1intum/prompt2/prompt-clients-template-component
       docker-file: clients/template_component/Dockerfile # Defaults to Dockerfile
@@ -86,7 +86,7 @@ jobs:
 
   interview:
     needs: clients-base
-    uses: ls1intum/.github/.github/workflows/build-and-push-docker-image.yml@v1.0.0
+    uses: ls1intum/.github/.github/workflows/build-and-push-docker-image.yml@v1.1.0
     with:
       image-name: ghcr.io/ls1intum/prompt2/prompt-clients-interview-component
       docker-file: clients/interview_component/Dockerfile # Defaults to Dockerfile
@@ -99,7 +99,7 @@ jobs:
 
   matching:
     needs: clients-base
-    uses: ls1intum/.github/.github/workflows/build-and-push-docker-image.yml@v1.0.0
+    uses: ls1intum/.github/.github/workflows/build-and-push-docker-image.yml@v1.1.0
     with:
       image-name: ghcr.io/ls1intum/prompt2/prompt-clients-matching-component
       docker-file: clients/matching_component/Dockerfile # Defaults to Dockerfile
@@ -112,7 +112,7 @@ jobs:
 
   intro-course-developer:
     needs: clients-base
-    uses: ls1intum/.github/.github/workflows/build-and-push-docker-image.yml@v1.0.0
+    uses: ls1intum/.github/.github/workflows/build-and-push-docker-image.yml@v1.1.0
     with:
       image-name: ghcr.io/ls1intum/prompt2/prompt-clients-intro-course-developer-component
       docker-file: clients/intro_course_developer_component/Dockerfile # Defaults to Dockerfile
@@ -125,7 +125,7 @@ jobs:
 
   intro-course-tutor:
     needs: clients-base
-    uses: ls1intum/.github/.github/workflows/build-and-push-docker-image.yml@v1.0.0
+    uses: ls1intum/.github/.github/workflows/build-and-push-docker-image.yml@v1.1.0
     with:
       image-name: ghcr.io/ls1intum/prompt2/prompt-clients-intro-course-tutor-component
       docker-file: clients/intro_course_tutor_component/Dockerfile # Defaults to Dockerfile
@@ -138,7 +138,7 @@ jobs:
 
   assessment:
     needs: clients-base
-    uses: ls1intum/.github/.github/workflows/build-and-push-docker-image.yml@v1.0.0
+    uses: ls1intum/.github/.github/workflows/build-and-push-docker-image.yml@v1.1.0
     with:
       image-name: ghcr.io/ls1intum/prompt2/prompt-clients-assessment-component
       docker-file: clients/assessment_component/Dockerfile # Defaults to Dockerfile
@@ -151,7 +151,7 @@ jobs:
 
   devops-challenge:
     needs: clients-base
-    uses: ls1intum/.github/.github/workflows/build-and-push-docker-image.yml@v1.0.0
+    uses: ls1intum/.github/.github/workflows/build-and-push-docker-image.yml@v1.1.0
     with:
       image-name: ghcr.io/ls1intum/prompt2/prompt-clients-devops-challenge-component
       docker-file: clients/devops_challenge_component/Dockerfile # Defaults to Dockerfile
@@ -164,7 +164,7 @@ jobs:
 
   team-allocation:
     needs: clients-base
-    uses: ls1intum/.github/.github/workflows/build-and-push-docker-image.yml@v1.0.0
+    uses: ls1intum/.github/.github/workflows/build-and-push-docker-image.yml@v1.1.0
     with:
       image-name: ghcr.io/ls1intum/prompt2/prompt-clients-team-allocation-component
       docker-file: clients/team_allocation_component/Dockerfile # Defaults to Dockerfile

--- a/.github/workflows/build-and-push-servers.yml
+++ b/.github/workflows/build-and-push-servers.yml
@@ -25,8 +25,7 @@ jobs:
       image-name: ghcr.io/ls1intum/prompt2/prompt-server-core # Defaults to the repository name
       docker-file: servers/Dockerfile # Defaults to Dockerfile
       docker-context: ./servers/core
-      build-args: |
-        "IMAGE_TAG=${{ inputs.release_tag }}"
+      tags: ${{ inputs.release_tag }}
     secrets: inherit
   intro-course:
     uses: ls1intum/.github/.github/workflows/build-and-push-docker-image.yml@v1.0.0
@@ -34,8 +33,7 @@ jobs:
       image-name: ghcr.io/ls1intum/prompt2/prompt-server-intro-course
       docker-file: servers/Dockerfile
       docker-context: ./servers/intro_course
-      build-args: |
-        "IMAGE_TAG=${{ inputs.release_tag }}"
+      tags: ${{ inputs.release_tag }}
     secrets: inherit
   team-allocation:
     uses: ls1intum/.github/.github/workflows/build-and-push-docker-image.yml@v1.0.0
@@ -43,6 +41,5 @@ jobs:
       image-name: ghcr.io/ls1intum/prompt2/prompt-server-team-allocation
       docker-file: servers/Dockerfile
       docker-context: ./servers/team_allocation
-      build-args: |
-        "IMAGE_TAG=${{ inputs.release_tag }}"
+      tags: ${{ inputs.release_tag }}
     secrets: inherit

--- a/.github/workflows/build-and-push-servers.yml
+++ b/.github/workflows/build-and-push-servers.yml
@@ -20,7 +20,7 @@ on:
 
 jobs:
   core:
-    uses: ls1intum/.github/.github/workflows/build-and-push-docker-image.yml@v1.0.0
+    uses: ls1intum/.github/.github/workflows/build-and-push-docker-image.yml@v1.1.0
     with:
       image-name: ghcr.io/ls1intum/prompt2/prompt-server-core # Defaults to the repository name
       docker-file: servers/Dockerfile # Defaults to Dockerfile
@@ -28,7 +28,7 @@ jobs:
       tags: ${{ inputs.release_tag }}
     secrets: inherit
   intro-course:
-    uses: ls1intum/.github/.github/workflows/build-and-push-docker-image.yml@v1.0.0
+    uses: ls1intum/.github/.github/workflows/build-and-push-docker-image.yml@v1.1.0
     with:
       image-name: ghcr.io/ls1intum/prompt2/prompt-server-intro-course
       docker-file: servers/Dockerfile
@@ -36,7 +36,7 @@ jobs:
       tags: ${{ inputs.release_tag }}
     secrets: inherit
   team-allocation:
-    uses: ls1intum/.github/.github/workflows/build-and-push-docker-image.yml@v1.0.0
+    uses: ls1intum/.github/.github/workflows/build-and-push-docker-image.yml@v1.1.0
     with:
       image-name: ghcr.io/ls1intum/prompt2/prompt-server-team-allocation
       docker-file: servers/Dockerfile

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -8,9 +8,13 @@ jobs:
   build-servers:
     uses: ./.github/workflows/build-and-push-servers.yml
     secrets: inherit
+    with:
+      release_tag: ${{ github.event.release.tag_name }}
   build-clients:
     uses: ./.github/workflows/build-and-push-clients.yml
     secrets: inherit
+    with:
+      release_tag: ${{ github.event.release.tag_name }}
   deploy-dev-container:
     needs: [build-clients, build-servers]
     uses: ./.github/workflows/deploy-docker.yml

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -9,12 +9,12 @@ jobs:
     uses: ./.github/workflows/build-and-push-servers.yml
     secrets: inherit
     with:
-      release_tag: ${{ github.event.release.tag_name }}
+      release_tag: "${{ github.event.release.tag_name }},latest"
   build-clients:
     uses: ./.github/workflows/build-and-push-clients.yml
     secrets: inherit
     with:
-      release_tag: ${{ github.event.release.tag_name }}
+      release_tag: "${{ github.event.release.tag_name }},latest"
   deploy-dev-container:
     needs: [build-clients, build-servers]
     uses: ./.github/workflows/deploy-docker.yml


### PR DESCRIPTION
This pull request includes changes to the `.github/workflows/prod.yml` file to improve the build process by incorporating the release tag into the build steps for both servers and clients.

Improvements to build process:

* [`.github/workflows/prod.yml`](diffhunk://#diff-b01f9374f6cc69f1d6b5f14f3c86dd1989076895b0d9d688f8fdddf35296acc6R11-R17): Added `release_tag` parameter to `build-servers` and `build-clients` steps to include the release tag from the GitHub event in the build process.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Enhanced the release workflow to automatically pass the designated release identifier during build and deployment.
  - Simplified image tagging across multiple jobs in the Docker build workflows for consistency and clarity.
  - Updated Docker image version from `v1.0.0` to `v1.1.0` for various jobs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->