### PR TITLE
`DevOpsChallenge`: Remove duplicate mutation call

### DIFF
--- a/clients/devops_challenge_component/src/devops_challenge/components/Assessment.tsx
+++ b/clients/devops_challenge_component/src/devops_challenge/components/Assessment.tsx
@@ -62,7 +62,6 @@ export const Assessment = (): JSX.Element => {
   })
 
   const handleTriggerAssessment = () => {
-    assessmentMutation.mutate()
     assessmentMutation.mutate(undefined, {
       onSettled: () => {
         setAssessmentTriggered(true)


### PR DESCRIPTION
Currently, the endpoint for testing is called twice.
I removed the duplicate call.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Enhanced the assessment trigger process to consistently update its status upon completion, ensuring that users receive reliable feedback after triggering an assessment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->