### PR TITLE
`General`: Fixing the Loading of Courses

### DIFF
--- a/clients/core/src/managementConsole/ManagementConsole.tsx
+++ b/clients/core/src/managementConsole/ManagementConsole.tsx
@@ -5,7 +5,7 @@ import { SidebarInset, SidebarProvider, SidebarTrigger } from '@/components/ui/s
 import { AppSidebar } from './layout/Sidebar/AppSidebar'
 import { WelcomePage } from './shared/components/WelcomePage'
 import { LoadingPage } from '@/components/LoadingPage'
-import React, { useEffect } from 'react'
+import React, { useEffect, useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { Course } from '@tumaet/prompt-shared-state'
 import { getAllCourses } from '../network/queries/course'
@@ -42,6 +42,7 @@ export const ManagementRoot = ({ children }: { children?: React.ReactNode }): JS
   } = useQuery<Course[]>({
     queryKey: ['courses'],
     queryFn: () => getAllCourses(),
+    enabled: !!keycloak,
   })
 
   // getting the course ids of the course a user is enrolled in
@@ -53,6 +54,7 @@ export const ManagementRoot = ({ children }: { children?: React.ReactNode }): JS
   } = useQuery<string[]>({
     queryKey: ['own_courses'],
     queryFn: () => getOwnCourseIDs(),
+    enabled: !!keycloak,
   })
 
   const refetch = () => {
@@ -106,12 +108,12 @@ export const ManagementRoot = ({ children }: { children?: React.ReactNode }): JS
     setSelectedCourseID,
   ])
 
-  if (isLoading) {
-    return <LoadingPage />
-  }
-
   if (isError) {
     return <ErrorPage onRetry={() => refetch()} onLogout={() => logout()} />
+  }
+
+  if (isLoading || !keycloak) {
+    return <LoadingPage />
   }
 
   // Check if the user has at least some Prompt rights

--- a/clients/core/src/managementConsole/ManagementConsole.tsx
+++ b/clients/core/src/managementConsole/ManagementConsole.tsx
@@ -67,13 +67,14 @@ export const ManagementRoot = ({ children }: { children?: React.ReactNode }): JS
 
   useEffect(() => {
     if (fetchedCourses) {
-      setCourses(fetchedCourses)
+      // Spreading into a new array forces an immutable update.
+      setCourses([...fetchedCourses])
     }
   }, [fetchedCourses, setCourses])
 
   useEffect(() => {
     if (fetchedOwnCourseIDs) {
-      setOwnCourseIDs(fetchedOwnCourseIDs)
+      setOwnCourseIDs([...fetchedOwnCourseIDs])
     }
   }, [fetchedOwnCourseIDs, setOwnCourseIDs])
 


### PR DESCRIPTION
## Problem
I noticed, that after re-login the courses are not correctly displayed in the sidebar. Only after reloading the side the courses are correctly displayed. 

## Solution
Upon inspection, the courses are not displayed because the requests fails with a 401 Unauthorized. The reason for this is, that it tries to fetch the courses before the keycloak token is correctly saved. 
Hence, I postponed the request until the keycloak token is correctly stored and can be used for the requests. No it works as expected. 