### PR TITLE
`DevOps Challenge`: Fix error message

### DIFF
--- a/clients/devops_challenge_component/src/devops_challenge/components/Assessment.tsx
+++ b/clients/devops_challenge_component/src/devops_challenge/components/Assessment.tsx
@@ -196,7 +196,9 @@ export const Assessment = (): JSX.Element => {
                   </AlertTitle>
                 </div>
                 <AlertDescription className={`mt-1 ${passed ? 'text-green-500' : ''}`}>
-                  {!passed ? (error ?? 'You failed the challenge.') : 'You passed the challenge!'}
+                  {!passed
+                    ? (error ?? 'Your last testing attempt failed')
+                    : 'You passed the challenge!'}
                 </AlertDescription>
               </Alert>
             ) : (

--- a/clients/devops_challenge_component/src/devops_challenge/components/Assessment.tsx
+++ b/clients/devops_challenge_component/src/devops_challenge/components/Assessment.tsx
@@ -197,7 +197,7 @@ export const Assessment = (): JSX.Element => {
                 </div>
                 <AlertDescription className={`mt-1 ${passed ? 'text-green-500' : ''}`}>
                   {!passed
-                    ? (error ?? 'Your last testing attempt failed')
+                    ? (error ?? 'Your last testing attempt did not pass')
                     : 'You passed the challenge!'}
                 </AlertDescription>
               </Alert>

--- a/clients/devops_challenge_component/src/devops_challenge/components/Assessment.tsx
+++ b/clients/devops_challenge_component/src/devops_challenge/components/Assessment.tsx
@@ -94,8 +94,10 @@ export const Assessment = (): JSX.Element => {
               {passed
                 ? 'Passed'
                 : !passed && (remainingAttempts !== maxAttempts || assessmentTriggered)
-                  ? 'Failed'
-                  : 'Not Started'}
+                  ? 'Not Passed'
+                  : !passed && remainingAttempts === 0
+                    ? 'Failed'
+                    : 'Not Started'}
             </Badge>
             <Badge
               variant='outline'
@@ -197,7 +199,7 @@ export const Assessment = (): JSX.Element => {
                 </div>
                 <AlertDescription className={`mt-1 ${passed ? 'text-green-500' : ''}`}>
                   {!passed
-                    ? (error ?? 'Your last testing attempt did not pass')
+                    ? (error ?? 'Your last testing attempt did not pass.')
                     : 'You passed the challenge!'}
                 </AlertDescription>
               </Alert>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Updated the badge text for assessment status: "Failed" is now displayed as "Not Passed" when the assessment has not been passed.
  - Introduced a condition to show "Failed" only when there are no remaining attempts.

- **Style**
  - Revised the alert message during an unsuccessful assessment attempt to read "Your last testing attempt did not pass," providing clearer feedback to users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->