### PR TITLE
`Intro Course`: Fixing Device UUID to UDID

### DIFF
--- a/clients/intro_course_developer_component/src/introCourse/interfaces/DeveloperProfile.ts
+++ b/clients/intro_course_developer_component/src/introCourse/interfaces/DeveloperProfile.ts
@@ -4,7 +4,7 @@ export type DeveloperProfile = {
   appleID: string
   gitLabUsername: string
   hasMacBook: boolean
-  iPhoneUUID?: string
-  iPadUUID?: string
-  appleWatchUUID?: string
+  iPhoneUDID?: string
+  iPadUDID?: string
+  appleWatchUDID?: string
 }

--- a/clients/intro_course_developer_component/src/introCourse/interfaces/PostDeveloperProfile.ts
+++ b/clients/intro_course_developer_component/src/introCourse/interfaces/PostDeveloperProfile.ts
@@ -2,7 +2,7 @@ export type PostDeveloperProfile = {
   appleID: string
   gitLabUsername: string
   hasMacBook: boolean
-  iPhoneUUID?: string
-  iPadUUID?: string
-  appleWatchUUID?: string
+  iPhoneUDID?: string
+  iPadUDID?: string
+  appleWatchUDID?: string
 }

--- a/clients/intro_course_developer_component/src/introCourse/pages/DeveloperProfile/DeveloperProfileForm.tsx
+++ b/clients/intro_course_developer_component/src/introCourse/pages/DeveloperProfile/DeveloperProfileForm.tsx
@@ -16,7 +16,7 @@ import { YesNoButtons } from '../../components/YesNoButtons'
 import { developerFormSchema, type DeveloperFormValues } from '../../validations/developerProfile'
 import { GitLabHelperDialog } from './components/GitLabHelperDialog'
 import { AppleIDHelperDialog } from './components/AppleIDHelperDialog'
-import IOSUUIDDialog from './components/IOSUUIDDialog'
+import IOSUDIDDialog from './components/IOSUDIDDialog'
 import { useScreenSize } from '@/hooks/useScreenSize'
 import { DeveloperProfile } from '../../interfaces/DeveloperProfile'
 
@@ -40,18 +40,18 @@ export const DeveloperProfileForm = ({
       gitLabUsername: developerProfile?.gitLabUsername || '',
       hasMacBook: developerProfile?.hasMacBook,
       hasIPhone:
-        developerProfile?.iPhoneUUID === undefined
+        developerProfile?.iPhoneUDID === undefined
           ? undefined
-          : developerProfile?.iPhoneUUID !== '',
-      iPhoneUUID: developerProfile?.iPhoneUUID || '',
+          : developerProfile?.iPhoneUDID !== '',
+      iPhoneUDID: developerProfile?.iPhoneUDID || '',
       hasIPad:
-        developerProfile?.iPadUUID === undefined ? undefined : developerProfile?.iPadUUID !== '',
-      iPadUUID: developerProfile?.iPadUUID || '',
+        developerProfile?.iPadUDID === undefined ? undefined : developerProfile?.iPadUDID !== '',
+      iPadUDID: developerProfile?.iPadUDID || '',
       hasAppleWatch:
-        developerProfile?.appleWatchUUID === undefined
+        developerProfile?.appleWatchUDID === undefined
           ? undefined
-          : developerProfile?.appleWatchUUID !== '',
-      appleWatchUUID: developerProfile?.appleWatchUUID || '',
+          : developerProfile?.appleWatchUDID !== '',
+      appleWatchUDID: developerProfile?.appleWatchUDID || '',
     },
   })
 
@@ -60,9 +60,9 @@ export const DeveloperProfileForm = ({
       appleID: values.appleID,
       gitLabUsername: values.gitLabUsername,
       hasMacBook: values.hasMacBook,
-      iPhoneUUID: values.hasIPhone ? values.iPhoneUUID : undefined,
-      iPadUUID: values.hasIPad ? values.iPadUUID : undefined,
-      appleWatchUUID: values.hasAppleWatch ? values.appleWatchUUID : undefined,
+      iPhoneUDID: values.hasIPhone ? values.iPhoneUDID : undefined,
+      iPadUDID: values.hasIPad ? values.iPadUDID : undefined,
+      appleWatchUDID: values.hasAppleWatch ? values.appleWatchUDID : undefined,
     }
     onSubmit(submittedProfile)
   }
@@ -136,7 +136,7 @@ export const DeveloperProfileForm = ({
             )}
           />
 
-          {/* iPhone Section: Yes/No + UUID Input */}
+          {/* iPhone Section: Yes/No + UDID Input */}
           <div className={`grid ${width > 800 ? 'grid-cols-4' : 'grid-cols-1'} gap-4 items-center`}>
             <div>
               <FormField
@@ -157,17 +157,17 @@ export const DeveloperProfileForm = ({
               <div className='col-span-3 h-full flex flex-col justify-end'>
                 <FormField
                   control={form.control}
-                  name='iPhoneUUID'
+                  name='iPhoneUDID'
                   render={({ field }) => (
                     <FormItem>
                       <FormControl>
                         <div className='flex items-center space-x-2'>
                           <Input
-                            placeholder="Enter your iPhone's UUID."
+                            placeholder="Enter your iPhone's UDID."
                             {...field}
                             className='w-full'
                           />
-                          <IOSUUIDDialog />
+                          <IOSUDIDDialog />
                         </div>
                       </FormControl>
                       <FormMessage />
@@ -178,7 +178,7 @@ export const DeveloperProfileForm = ({
             )}
           </div>
 
-          {/* iPad Section: Yes/No + UUID Input */}
+          {/* iPad Section: Yes/No + UDID Input */}
           <div className={`grid ${width > 800 ? 'grid-cols-4' : 'grid-cols-1'} gap-4 items-center`}>
             <div>
               <FormField
@@ -199,17 +199,17 @@ export const DeveloperProfileForm = ({
               <div className='col-span-3 h-full flex flex-col justify-end'>
                 <FormField
                   control={form.control}
-                  name='iPadUUID'
+                  name='iPadUDID'
                   render={({ field }) => (
                     <FormItem>
                       <FormControl>
                         <div className='flex items-center space-x-2'>
                           <Input
-                            placeholder="Enter your iPad's UUID."
+                            placeholder="Enter your iPad's UDID."
                             {...field}
                             className='w-full'
                           />
-                          <IOSUUIDDialog />
+                          <IOSUDIDDialog />
                         </div>
                       </FormControl>
                       <FormMessage />
@@ -220,7 +220,7 @@ export const DeveloperProfileForm = ({
             )}
           </div>
 
-          {/* Apple Watch Section: Yes/No + UUID Input */}
+          {/* Apple Watch Section: Yes/No + UDID Input */}
           <div className={`grid ${width > 800 ? 'grid-cols-4' : 'grid-cols-1'} gap-4 items-center`}>
             <div>
               <FormField
@@ -241,17 +241,17 @@ export const DeveloperProfileForm = ({
               <div className='col-span-3 h-full flex flex-col justify-end'>
                 <FormField
                   control={form.control}
-                  name='appleWatchUUID'
+                  name='appleWatchUDID'
                   render={({ field }) => (
                     <FormItem>
                       <FormControl>
                         <div className='flex items-center space-x-2'>
                           <Input
-                            placeholder="Enter your Apple Watch's UUID."
+                            placeholder="Enter your Apple Watch's UDID."
                             {...field}
                             className='w-full'
                           />
-                          <IOSUUIDDialog />
+                          <IOSUDIDDialog />
                         </div>
                       </FormControl>
                       <FormMessage />

--- a/clients/intro_course_developer_component/src/introCourse/pages/DeveloperProfile/components/IOSUDIDDialog.tsx
+++ b/clients/intro_course_developer_component/src/introCourse/pages/DeveloperProfile/components/IOSUDIDDialog.tsx
@@ -12,7 +12,7 @@ import {
 import { Separator } from '@/components/ui/separator'
 import { Smartphone, Laptop, HelpCircle } from 'lucide-react'
 
-export default function IOSUUIDDialog() {
+export default function IOSUDIDDialog() {
   const [open, setOpen] = useState(false)
 
   const instructions = [
@@ -50,7 +50,7 @@ export default function IOSUUIDDialog() {
         {
           title: 'Copy device ID',
           description:
-            'Control-click the label (UUID) to copy your device ID. The UUID is of the form "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX".',
+            'Control-click the label (UDID) to copy your device ID. The UDID is of the form "XXXXXXXX-XXXXXXXXXXXXXXXX".',
         },
       ],
     },
@@ -69,7 +69,7 @@ export default function IOSUUIDDialog() {
         {
           title: 'Copy device ID',
           description:
-            'Highlight the device ID (labeled as Identifier) to copy it. The UUID is of the form "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX".',
+            'Highlight the device ID (labeled as Identifier) to copy it. The UDID is of the form "XXXXXXXX-XXXXXXXXXXXXXXXX".',
         },
       ],
     },
@@ -86,9 +86,9 @@ export default function IOSUUIDDialog() {
         </DialogTrigger>
         <DialogContent className='max-w-2xl flex flex-col max-h-[90vh]'>
           <DialogHeader className='border-b pb-4'>
-            <DialogTitle>Getting iOS Device UUID</DialogTitle>
+            <DialogTitle>Getting iOS Device UDID</DialogTitle>
             <DialogDescription>
-              Follow these steps to obtain the UUID (Unique Device Identifier) of your iOS device
+              Follow these steps to obtain the UDID (Unique Device Identifier) of your iOS device
             </DialogDescription>
           </DialogHeader>
 

--- a/clients/intro_course_developer_component/src/introCourse/pages/DeveloperProfilesLecturer/DeveloperProfilesLecturerPage.tsx
+++ b/clients/intro_course_developer_component/src/introCourse/pages/DeveloperProfilesLecturer/DeveloperProfilesLecturerPage.tsx
@@ -218,13 +218,13 @@ export const DeveloperProfilesLecturerPage = () => {
               <TableCell>
                 <div className='flex gap-2'>
                   {profile?.hasMacBook && <Laptop className='h-5 w-5 text-slate-600' />}
-                  {profile?.iPhoneUUID && <Smartphone className='h-5 w-5 text-slate-600' />}
-                  {profile?.iPadUUID && <Tablet className='h-5 w-5 text-slate-600' />}
-                  {profile?.appleWatchUUID && <Watch className='h-5 w-5 text-slate-600' />}
+                  {profile?.iPhoneUDID && <Smartphone className='h-5 w-5 text-slate-600' />}
+                  {profile?.iPadUDID && <Tablet className='h-5 w-5 text-slate-600' />}
+                  {profile?.appleWatchUDID && <Watch className='h-5 w-5 text-slate-600' />}
                   {!profile?.hasMacBook &&
-                    !profile?.iPhoneUUID &&
-                    !profile?.iPadUUID &&
-                    !profile?.appleWatchUUID && (
+                    !profile?.iPhoneUDID &&
+                    !profile?.iPadUDID &&
+                    !profile?.appleWatchUDID && (
                       <span className='text-muted-foreground text-sm italic'>No devices</span>
                     )}
                 </div>

--- a/clients/intro_course_developer_component/src/introCourse/pages/DeveloperProfilesLecturer/components/ProfileDetailsDialog.tsx
+++ b/clients/intro_course_developer_component/src/introCourse/pages/DeveloperProfilesLecturer/components/ProfileDetailsDialog.tsx
@@ -54,9 +54,9 @@ export const ProfileDetailsDialog: React.FC<ProfileDetailsDialogProps> = ({
       appleID: profile?.appleID || '',
       gitLabUsername: profile?.gitLabUsername || '',
       hasMacBook: profile?.hasMacBook || false,
-      iPhoneUUID: profile?.iPhoneUUID || '',
-      iPadUUID: profile?.iPadUUID || '',
-      appleWatchUUID: profile?.appleWatchUUID || '',
+      iPhoneUDID: profile?.iPhoneUDID || '',
+      iPadUDID: profile?.iPadUDID || '',
+      appleWatchUDID: profile?.appleWatchUDID || '',
     },
   })
 
@@ -163,14 +163,14 @@ export const ProfileDetailsDialog: React.FC<ProfileDetailsDialogProps> = ({
 
               <FormField
                 control={form.control}
-                name='iPhoneUUID'
+                name='iPhoneUDID'
                 render={({ field }) => (
                   <FormItem>
                     <FormLabel className='flex items-center gap-2'>
-                      <Smartphone className='h-5 w-5' /> iPhone UUID
+                      <Smartphone className='h-5 w-5' /> iPhone UDID
                     </FormLabel>
                     <FormControl>
-                      <Input placeholder='iPhone UUID (optional)' disabled={isPending} {...field} />
+                      <Input placeholder='iPhone UDID (optional)' disabled={isPending} {...field} />
                     </FormControl>
                     <FormMessage />
                   </FormItem>
@@ -179,14 +179,14 @@ export const ProfileDetailsDialog: React.FC<ProfileDetailsDialogProps> = ({
 
               <FormField
                 control={form.control}
-                name='iPadUUID'
+                name='iPadUDID'
                 render={({ field }) => (
                   <FormItem>
                     <FormLabel className='flex items-center gap-2'>
-                      <Tablet className='h-5 w-5' /> iPad UUID
+                      <Tablet className='h-5 w-5' /> iPad UDID
                     </FormLabel>
                     <FormControl>
-                      <Input placeholder='iPad UUID (optional)' disabled={isPending} {...field} />
+                      <Input placeholder='iPad UDID (optional)' disabled={isPending} {...field} />
                     </FormControl>
                     <FormMessage />
                   </FormItem>
@@ -195,15 +195,15 @@ export const ProfileDetailsDialog: React.FC<ProfileDetailsDialogProps> = ({
 
               <FormField
                 control={form.control}
-                name='appleWatchUUID'
+                name='appleWatchUDID'
                 render={({ field }) => (
                   <FormItem>
                     <FormLabel className='flex items-center gap-2'>
-                      <Watch className='h-5 w-5' /> Apple Watch UUID
+                      <Watch className='h-5 w-5' /> Apple Watch UDID
                     </FormLabel>
                     <FormControl>
                       <Input
-                        placeholder='Apple Watch UUID (optional)'
+                        placeholder='Apple Watch UDID (optional)'
                         disabled={isPending}
                         {...field}
                       />

--- a/clients/intro_course_developer_component/src/introCourse/pages/DeveloperProfilesLecturer/hooks/useGetFilteredParticipations.tsx
+++ b/clients/intro_course_developer_component/src/introCourse/pages/DeveloperProfilesLecturer/hooks/useGetFilteredParticipations.tsx
@@ -35,13 +35,13 @@ export const useGetFilteredParticipations = (
         passesDevices = passesDevices && !!(profile && profile.hasMacBook)
       }
       if (filters.devices.iPhone) {
-        passesDevices = passesDevices && !!(profile && profile.iPhoneUUID)
+        passesDevices = passesDevices && !!(profile && profile.iPhoneUDID)
       }
       if (filters.devices.iPad) {
-        passesDevices = passesDevices && !!(profile && profile.iPadUUID)
+        passesDevices = passesDevices && !!(profile && profile.iPadUDID)
       }
       if (filters.devices.appleWatch) {
-        passesDevices = passesDevices && !!(profile && profile.appleWatchUUID)
+        passesDevices = passesDevices && !!(profile && profile.appleWatchUDID)
       }
       if (filters.devices.noDevices) {
         // "No Devices" means there is no profile or the profile has none of the devices.
@@ -49,9 +49,9 @@ export const useGetFilteredParticipations = (
           passesDevices &&
           (!profile ||
             (!profile.hasMacBook &&
-              !profile.iPhoneUUID &&
-              !profile.iPadUUID &&
-              !profile.appleWatchUUID))
+              !profile.iPhoneUDID &&
+              !profile.iPadUDID &&
+              !profile.appleWatchUDID))
       }
 
       return passesSurvey && passesDevices

--- a/clients/intro_course_developer_component/src/introCourse/validations/developerProfile.ts
+++ b/clients/intro_course_developer_component/src/introCourse/validations/developerProfile.ts
@@ -1,38 +1,44 @@
 import * as z from 'zod'
 
+const udidSchema = z
+  .union([
+    z.string().regex(/^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{16}$/, 'Invalid UDID format'),
+    z.literal(''),
+  ])
+  .optional()
+
 export const developerFormSchema = z
   .object({
     appleID: z.string().email('Apple ID must be a valid email address'),
     gitLabUsername: z.string().min(1, 'GitLab username is required'),
     hasMacBook: z.boolean(),
     hasIPhone: z.boolean(),
-    iPhoneUUID: z.union([z.string().uuid('Invalid UUID'), z.literal('')]).optional(),
+    iPhoneUDID: udidSchema,
     hasIPad: z.boolean(),
-    iPadUUID: z.union([z.string().uuid('Invalid UUID'), z.literal('')]).optional(),
+    iPadUDID: udidSchema,
     hasAppleWatch: z.boolean(),
-    appleWatchUUID: z.union([z.string().uuid('Invalid UUID'), z.literal('')]).optional(),
+    appleWatchUDID: udidSchema,
   })
   .superRefine((values, ctx) => {
-    // If the user answered "yes", then require a UUID.
-    if (values.hasIPhone && (!values.iPhoneUUID || values.iPhoneUUID === '')) {
+    if (values.hasIPhone && (!values.iPhoneUDID || values.iPhoneUDID === '')) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
-        message: 'iPhone UUID is required when you have an iPhone',
-        path: ['iPhoneUUID'],
+        message: 'iPhone UDID is required when you have an iPhone',
+        path: ['iPhoneUDID'],
       })
     }
-    if (values.hasIPad && (!values.iPadUUID || values.iPadUUID === '')) {
+    if (values.hasIPad && (!values.iPadUDID || values.iPadUDID === '')) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
-        message: 'iPad UUID is required when you have an iPad',
-        path: ['iPadUUID'],
+        message: 'iPad UDID is required when you have an iPad',
+        path: ['iPadUDID'],
       })
     }
-    if (values.hasAppleWatch && (!values.appleWatchUUID || values.appleWatchUUID === '')) {
+    if (values.hasAppleWatch && (!values.appleWatchUDID || values.appleWatchUDID === '')) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
-        message: 'Apple Watch UUID is required when you have an Apple Watch',
-        path: ['appleWatchUUID'],
+        message: 'Apple Watch UDID is required when you have an Apple Watch',
+        path: ['appleWatchUDID'],
       })
     }
   })

--- a/clients/intro_course_developer_component/src/introCourse/validations/instructorDevProfile.ts
+++ b/clients/intro_course_developer_component/src/introCourse/validations/instructorDevProfile.ts
@@ -4,18 +4,27 @@ export const instructorDevProfile = z.object({
   appleID: z.string().email('Invalid email address'),
   gitLabUsername: z.string(),
   hasMacBook: z.boolean(),
-  // Preprocess empty strings to undefined before validating UUID
-  iPhoneUUID: z.preprocess(
+  // Preprocess empty strings to undefined before validating UDID
+  iPhoneUDID: z.preprocess(
     (a) => (a === '' ? undefined : a),
-    z.string().uuid('Invalid iPhone UUID').optional(),
+    z
+      .string()
+      .regex(/^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{16}$/, 'Invalid iPhone UDID')
+      .optional(),
   ),
-  iPadUUID: z.preprocess(
+  iPadUDID: z.preprocess(
     (a) => (a === '' ? undefined : a),
-    z.string().uuid('Invalid iPad UUID').optional(),
+    z
+      .string()
+      .regex(/^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{16}$/, 'Invalid iPad UDID')
+      .optional(),
   ),
-  appleWatchUUID: z.preprocess(
+  appleWatchUDID: z.preprocess(
     (a) => (a === '' ? undefined : a),
-    z.string().uuid('Invalid Apple Watch UUID').optional(),
+    z
+      .string()
+      .regex(/^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{16}$/, 'Invalid Apple Watch UDID')
+      .optional(),
   ),
 })
 

--- a/servers/intro_course/db/migration/0003_udid.up.sql
+++ b/servers/intro_course/db/migration/0003_udid.up.sql
@@ -1,0 +1,21 @@
+BEGIN;
+
+-- Alter and rename iphone_uuid to iphone_udid
+ALTER TABLE developer_profile
+  ALTER COLUMN iphone_uuid TYPE text USING iphone_uuid::text;
+ALTER TABLE developer_profile
+  RENAME COLUMN iphone_uuid TO iphone_udid;
+
+-- Alter and rename ipad_uuid to ipad_udid
+ALTER TABLE developer_profile
+  ALTER COLUMN ipad_uuid TYPE text USING ipad_uuid::text;
+ALTER TABLE developer_profile
+  RENAME COLUMN ipad_uuid TO ipad_udid;
+
+-- Alter and rename apple_watch_uuid to apple_watch_udid
+ALTER TABLE developer_profile
+  ALTER COLUMN apple_watch_uuid TYPE text USING apple_watch_uuid::text;
+ALTER TABLE developer_profile
+  RENAME COLUMN apple_watch_uuid TO apple_watch_udid;
+
+COMMIT;

--- a/servers/intro_course/db/query/developerProfile.sql
+++ b/servers/intro_course/db/query/developerProfile.sql
@@ -10,7 +10,7 @@ WHERE course_participation_id = $1
 AND course_phase_id = $2;
 
 -- name: CreateDeveloperProfile :exec
-INSERT INTO developer_profile (course_participation_id, course_phase_id, gitlab_username, apple_id, has_macbook, iphone_uuid, ipad_uuid, apple_watch_uuid)
+INSERT INTO developer_profile (course_participation_id, course_phase_id, gitlab_username, apple_id, has_macbook, iphone_udid, ipad_udid, apple_watch_udid)
 VALUES ($1, $2, $3, $4, $5, $6, $7, $8);
 
 
@@ -21,9 +21,9 @@ INSERT INTO developer_profile (
   gitlab_username,
   apple_id,
   has_macbook,
-  iphone_uuid,
-  ipad_uuid,
-  apple_watch_uuid
+  iphone_udid,
+  ipad_udid,
+  apple_watch_udid
 )
 VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
 ON CONFLICT (course_phase_id, course_participation_id)
@@ -31,6 +31,6 @@ DO UPDATE SET
   gitlab_username   = EXCLUDED.gitlab_username,
   apple_id          = EXCLUDED.apple_id,
   has_macbook       = EXCLUDED.has_macbook,
-  iphone_uuid       = EXCLUDED.iphone_uuid,
-  ipad_uuid         = EXCLUDED.ipad_uuid,
-  apple_watch_uuid  = EXCLUDED.apple_watch_uuid;
+  iphone_udid       = EXCLUDED.iphone_udid,
+  ipad_udid         = EXCLUDED.ipad_udid,
+  apple_watch_udid  = EXCLUDED.apple_watch_udid;

--- a/servers/intro_course/db/sqlc/developerProfile.sql.go
+++ b/servers/intro_course/db/sqlc/developerProfile.sql.go
@@ -13,7 +13,7 @@ import (
 )
 
 const createDeveloperProfile = `-- name: CreateDeveloperProfile :exec
-INSERT INTO developer_profile (course_participation_id, course_phase_id, gitlab_username, apple_id, has_macbook, iphone_uuid, ipad_uuid, apple_watch_uuid)
+INSERT INTO developer_profile (course_participation_id, course_phase_id, gitlab_username, apple_id, has_macbook, iphone_udid, ipad_udid, apple_watch_udid)
 VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
 `
 
@@ -23,9 +23,9 @@ type CreateDeveloperProfileParams struct {
 	GitlabUsername        string      `json:"gitlab_username"`
 	AppleID               string      `json:"apple_id"`
 	HasMacbook            bool        `json:"has_macbook"`
-	IphoneUuid            pgtype.UUID `json:"iphone_uuid"`
-	IpadUuid              pgtype.UUID `json:"ipad_uuid"`
-	AppleWatchUuid        pgtype.UUID `json:"apple_watch_uuid"`
+	IphoneUdid            pgtype.Text `json:"iphone_udid"`
+	IpadUdid              pgtype.Text `json:"ipad_udid"`
+	AppleWatchUdid        pgtype.Text `json:"apple_watch_udid"`
 }
 
 func (q *Queries) CreateDeveloperProfile(ctx context.Context, arg CreateDeveloperProfileParams) error {
@@ -35,9 +35,9 @@ func (q *Queries) CreateDeveloperProfile(ctx context.Context, arg CreateDevelope
 		arg.GitlabUsername,
 		arg.AppleID,
 		arg.HasMacbook,
-		arg.IphoneUuid,
-		arg.IpadUuid,
-		arg.AppleWatchUuid,
+		arg.IphoneUdid,
+		arg.IpadUdid,
+		arg.AppleWatchUdid,
 	)
 	return err
 }
@@ -49,9 +49,9 @@ INSERT INTO developer_profile (
   gitlab_username,
   apple_id,
   has_macbook,
-  iphone_uuid,
-  ipad_uuid,
-  apple_watch_uuid
+  iphone_udid,
+  ipad_udid,
+  apple_watch_udid
 )
 VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
 ON CONFLICT (course_phase_id, course_participation_id)
@@ -59,9 +59,9 @@ DO UPDATE SET
   gitlab_username   = EXCLUDED.gitlab_username,
   apple_id          = EXCLUDED.apple_id,
   has_macbook       = EXCLUDED.has_macbook,
-  iphone_uuid       = EXCLUDED.iphone_uuid,
-  ipad_uuid         = EXCLUDED.ipad_uuid,
-  apple_watch_uuid  = EXCLUDED.apple_watch_uuid
+  iphone_udid       = EXCLUDED.iphone_udid,
+  ipad_udid         = EXCLUDED.ipad_udid,
+  apple_watch_udid  = EXCLUDED.apple_watch_udid
 `
 
 type CreateOrUpdateDeveloperProfileParams struct {
@@ -70,9 +70,9 @@ type CreateOrUpdateDeveloperProfileParams struct {
 	GitlabUsername        string      `json:"gitlab_username"`
 	AppleID               string      `json:"apple_id"`
 	HasMacbook            bool        `json:"has_macbook"`
-	IphoneUuid            pgtype.UUID `json:"iphone_uuid"`
-	IpadUuid              pgtype.UUID `json:"ipad_uuid"`
-	AppleWatchUuid        pgtype.UUID `json:"apple_watch_uuid"`
+	IphoneUdid            pgtype.Text `json:"iphone_udid"`
+	IpadUdid              pgtype.Text `json:"ipad_udid"`
+	AppleWatchUdid        pgtype.Text `json:"apple_watch_udid"`
 }
 
 func (q *Queries) CreateOrUpdateDeveloperProfile(ctx context.Context, arg CreateOrUpdateDeveloperProfileParams) error {
@@ -82,15 +82,15 @@ func (q *Queries) CreateOrUpdateDeveloperProfile(ctx context.Context, arg Create
 		arg.GitlabUsername,
 		arg.AppleID,
 		arg.HasMacbook,
-		arg.IphoneUuid,
-		arg.IpadUuid,
-		arg.AppleWatchUuid,
+		arg.IphoneUdid,
+		arg.IpadUdid,
+		arg.AppleWatchUdid,
 	)
 	return err
 }
 
 const getAllDeveloperProfiles = `-- name: GetAllDeveloperProfiles :many
-SELECT course_phase_id, course_participation_id, gitlab_username, apple_id, has_macbook, iphone_uuid, ipad_uuid, apple_watch_uuid 
+SELECT course_phase_id, course_participation_id, gitlab_username, apple_id, has_macbook, iphone_udid, ipad_udid, apple_watch_udid 
 FROM developer_profile
 WHERE course_phase_id = $1
 `
@@ -110,9 +110,9 @@ func (q *Queries) GetAllDeveloperProfiles(ctx context.Context, coursePhaseID uui
 			&i.GitlabUsername,
 			&i.AppleID,
 			&i.HasMacbook,
-			&i.IphoneUuid,
-			&i.IpadUuid,
-			&i.AppleWatchUuid,
+			&i.IphoneUdid,
+			&i.IpadUdid,
+			&i.AppleWatchUdid,
 		); err != nil {
 			return nil, err
 		}
@@ -125,7 +125,7 @@ func (q *Queries) GetAllDeveloperProfiles(ctx context.Context, coursePhaseID uui
 }
 
 const getDeveloperProfileByCourseParticipationID = `-- name: GetDeveloperProfileByCourseParticipationID :one
-SELECT course_phase_id, course_participation_id, gitlab_username, apple_id, has_macbook, iphone_uuid, ipad_uuid, apple_watch_uuid
+SELECT course_phase_id, course_participation_id, gitlab_username, apple_id, has_macbook, iphone_udid, ipad_udid, apple_watch_udid
 FROM developer_profile
 WHERE course_participation_id = $1 
 AND course_phase_id = $2
@@ -145,9 +145,9 @@ func (q *Queries) GetDeveloperProfileByCourseParticipationID(ctx context.Context
 		&i.GitlabUsername,
 		&i.AppleID,
 		&i.HasMacbook,
-		&i.IphoneUuid,
-		&i.IpadUuid,
-		&i.AppleWatchUuid,
+		&i.IphoneUdid,
+		&i.IpadUdid,
+		&i.AppleWatchUdid,
 	)
 	return i, err
 }

--- a/servers/intro_course/db/sqlc/models.go
+++ b/servers/intro_course/db/sqlc/models.go
@@ -15,9 +15,9 @@ type DeveloperProfile struct {
 	GitlabUsername        string      `json:"gitlab_username"`
 	AppleID               string      `json:"apple_id"`
 	HasMacbook            bool        `json:"has_macbook"`
-	IphoneUuid            pgtype.UUID `json:"iphone_uuid"`
-	IpadUuid              pgtype.UUID `json:"ipad_uuid"`
-	AppleWatchUuid        pgtype.UUID `json:"apple_watch_uuid"`
+	IphoneUdid            pgtype.Text `json:"iphone_udid"`
+	IpadUdid              pgtype.Text `json:"ipad_udid"`
+	AppleWatchUdid        pgtype.Text `json:"apple_watch_udid"`
 }
 
 type Seat struct {

--- a/servers/intro_course/developerProfile/developerProfileDTO/get_developer_profile.go
+++ b/servers/intro_course/developerProfile/developerProfileDTO/get_developer_profile.go
@@ -12,9 +12,9 @@ type DeveloperProfile struct {
 	AppleID               string      `json:"appleID"`
 	GitLabUsername        string      `json:"gitLabUsername"`
 	HasMacBook            bool        `json:"hasMacBook"`
-	IPhoneUUID            pgtype.UUID `json:"iPhoneUUID"`
-	IPadUUID              pgtype.UUID `json:"iPadUUID"`
-	AppleWatchUUID        pgtype.UUID `json:"appleWatchUUID"`
+	IPhoneUDID            pgtype.Text `json:"iPhoneUDID"`
+	IPadUDID              pgtype.Text `json:"iPadUDID"`
+	AppleWatchUDID        pgtype.Text `json:"appleWatchUDID"`
 }
 
 func GetDeveloperProfileDTOFromDBModel(model db.DeveloperProfile) DeveloperProfile {
@@ -24,9 +24,9 @@ func GetDeveloperProfileDTOFromDBModel(model db.DeveloperProfile) DeveloperProfi
 		AppleID:               model.AppleID,
 		GitLabUsername:        model.GitlabUsername,
 		HasMacBook:            model.HasMacbook,
-		IPhoneUUID:            model.IphoneUuid,
-		IPadUUID:              model.IpadUuid,
-		AppleWatchUUID:        model.AppleWatchUuid,
+		IPhoneUDID:            model.IphoneUdid,
+		IPadUDID:              model.IpadUdid,
+		AppleWatchUDID:        model.AppleWatchUdid,
 	}
 }
 

--- a/servers/intro_course/developerProfile/developerProfileDTO/post_developer_profile.go
+++ b/servers/intro_course/developerProfile/developerProfileDTO/post_developer_profile.go
@@ -10,9 +10,9 @@ type PostDeveloperProfile struct {
 	AppleID        string      `json:"appleID"`
 	GitLabUsername string      `json:"gitLabUsername"`
 	HasMacBook     bool        `json:"hasMacBook"`
-	IPhoneUUID     pgtype.UUID `json:"iPhoneUUID"`
-	IPadUUID       pgtype.UUID `json:"iPadUUID"`
-	AppleWatchUUID pgtype.UUID `json:"appleWatchUUID"`
+	IPhoneUDID     pgtype.Text `json:"iPhoneUDID"`
+	IPadUDID       pgtype.Text `json:"iPadUDID"`
+	AppleWatchUDID pgtype.Text `json:"appleWatchUDID"`
 }
 
 func GetDeveloperProfileDTOFromPostRequest(request PostDeveloperProfile, coursePhaseID, courseParticipationID uuid.UUID) db.CreateDeveloperProfileParams {
@@ -22,9 +22,9 @@ func GetDeveloperProfileDTOFromPostRequest(request PostDeveloperProfile, courseP
 		AppleID:               request.AppleID,
 		GitlabUsername:        request.GitLabUsername,
 		HasMacbook:            request.HasMacBook,
-		IphoneUuid:            request.IPhoneUUID,
-		IpadUuid:              request.IPadUUID,
-		AppleWatchUuid:        request.AppleWatchUUID,
+		IphoneUdid:            request.IPhoneUDID,
+		IpadUdid:              request.IPadUDID,
+		AppleWatchUdid:        request.AppleWatchUDID,
 	}
 }
 
@@ -35,8 +35,8 @@ func GetDeveloperProfileDTOFromCreateRequest(request DeveloperProfile, coursePha
 		AppleID:               request.AppleID,
 		GitlabUsername:        request.GitLabUsername,
 		HasMacbook:            request.HasMacBook,
-		IphoneUuid:            request.IPhoneUUID,
-		IpadUuid:              request.IPadUUID,
-		AppleWatchUuid:        request.AppleWatchUUID,
+		IphoneUdid:            request.IPhoneUDID,
+		IpadUdid:              request.IPadUDID,
+		AppleWatchUdid:        request.AppleWatchUDID,
 	}
 }

--- a/servers/intro_course/developerProfile/router.go
+++ b/servers/intro_course/developerProfile/router.go
@@ -42,6 +42,13 @@ func createDeveloperProfile(c *gin.Context) {
 		return
 	}
 
+	err = validateDeveloperProfileUDIDs(request)
+	if err != nil {
+		log.Error("Error validating UDIDs: ", err)
+		handleError(c, http.StatusBadRequest, err)
+		return
+	}
+
 	err = CreateDeveloperProfile(c, coursePhaseID, courseParticipationID.(uuid.UUID), request)
 	if err != nil {
 		handleError(c, http.StatusInternalServerError, err)

--- a/servers/intro_course/developerProfile/validation.go
+++ b/servers/intro_course/developerProfile/validation.go
@@ -1,0 +1,37 @@
+package developerProfile
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/ls1intum/prompt2/servers/intro_course/developerProfile/developerProfileDTO"
+)
+
+// udidRegex validates a UDID of the form "XXXXXXXX-XXXXXXXXXXXXXXXX"
+// where X is a hexadecimal digit.
+var udidRegex = regexp.MustCompile(`^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{16}$`)
+
+// isValidUDID returns true if the given pgtype.Text UDID is valid.
+// If udid.Valid is false, meaning no UDID was provided, it returns true.
+func isValidUDID(udid pgtype.Text) bool {
+	if !udid.Valid {
+		// No UDID provided is considered valid.
+		return true
+	}
+	return udidRegex.MatchString(udid.String)
+}
+
+// validateDeveloperProfileUDIDs checks all UDID fields in the profile DTO.
+func validateDeveloperProfileUDIDs(profile developerProfileDTO.PostDeveloperProfile) error {
+	if !isValidUDID(profile.IPhoneUDID) {
+		return fmt.Errorf("invalid iPhone UDID")
+	}
+	if !isValidUDID(profile.IPadUDID) {
+		return fmt.Errorf("invalid iPad UDID")
+	}
+	if !isValidUDID(profile.AppleWatchUDID) {
+		return fmt.Errorf("invalid Apple Watch UDID")
+	}
+	return nil
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Standardized device identifier naming from “UUID” to “UDID” for iPhone, iPad, and Apple Watch across profiles, forms, dialogs, and notifications.
  - Updated text labels, placeholders, and validation error messages to enhance clarity and maintain consistency.
  - Improved data validation and storage logic to support the new UDID format uniformly across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->