### PR TITLE
Fix typo in context path for server in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   server:
     build:
-      context: ./server
+      context: ./servers
       dockerfile: Dockerfile
     container_name: prompt-core-server
     depends_on:


### PR DESCRIPTION
This pull request includes a small change to the `docker-compose.yml` file. The change updates the build context for the `server` service to point to the correct directory.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the build context path for the server service in the deployment configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->