### PR TITLE
`Core`: Improving Application Auth

### DIFF
--- a/servers/core/applicationAdministration/router.go
+++ b/servers/core/applicationAdministration/router.go
@@ -125,20 +125,24 @@ func getApplicationFormWithCourseDetails(c *gin.Context) {
 }
 
 func getApplicationAuthenticated(c *gin.Context) {
-	coursePhaseId, err := uuid.Parse(c.Param("coursePhaseID"))
+	coursePhaseID, err := uuid.Parse(c.Param("coursePhaseID"))
 	if err != nil {
 		handleError(c, http.StatusBadRequest, err)
 		return
 	}
-	userEmail := c.GetString("userEmail")
-
-	if userEmail == "" {
-		handleError(c, http.StatusUnauthorized, errors.New("no user email found"))
+	matriculationNumber := c.GetString("matriculationNumber")
+	if matriculationNumber == "" {
+		handleError(c, http.StatusUnauthorized, errors.New("no matriculation number found"))
 		return
 	}
 
-	// TODO: maybe rewrite in near future to MatrNr as this is safer to not change!
-	applicationForm, err := GetApplicationAuthenticatedByEmail(c, userEmail, coursePhaseId)
+	universityLogin := c.GetString("universityLogin")
+	if universityLogin == "" {
+		handleError(c, http.StatusUnauthorized, errors.New("no university login found"))
+		return
+	}
+
+	applicationForm, err := GetApplicationAuthenticatedByMatriculationNumberAndUniversityLogin(c, coursePhaseID, matriculationNumber, universityLogin)
 	if err != nil {
 		log.Error(err)
 		handleError(c, http.StatusInternalServerError, errors.New("could not get application form"))

--- a/servers/core/applicationAdministration/service.go
+++ b/servers/core/applicationAdministration/service.go
@@ -302,11 +302,11 @@ func PostApplicationExtern(ctx context.Context, coursePhaseID uuid.UUID, applica
 	return cPhaseParticipation.CourseParticipationID, nil
 }
 
-func GetApplicationAuthenticatedByEmail(ctx context.Context, email string, coursePhaseID uuid.UUID) (applicationDTO.Application, error) {
+func GetApplicationAuthenticatedByMatriculationNumberAndUniversityLogin(ctx context.Context, coursePhaseID uuid.UUID, matriculationNumber string, universityLogin string) (applicationDTO.Application, error) {
 	ctxWithTimeout, cancel := db.GetTimeoutContext(ctx)
 	defer cancel()
 
-	studentObj, err := student.GetStudentByEmail(ctxWithTimeout, email)
+	studentObj, err := student.GetStudentByMatriculationNumberAndUniversityLogin(ctxWithTimeout, matriculationNumber, universityLogin)
 	if err != nil && errors.Is(err, sql.ErrNoRows) {
 		return applicationDTO.Application{
 			Status:             applicationDTO.StatusNewUser,

--- a/servers/core/applicationAdministration/service_test.go
+++ b/servers/core/applicationAdministration/service_test.go
@@ -258,11 +258,12 @@ func (suite *ApplicationAdminServiceTestSuite) TestPostApplicationExtern_Already
 	assert.Equal(suite.T(), ErrAlreadyApplied, err)
 }
 
-func (suite *ApplicationAdminServiceTestSuite) TestGetApplicationAuthenticatedByEmail_NotApplied() {
-	email := "existingstudent@example.com"
+func (suite *ApplicationAdminServiceTestSuite) TestGetApplicationAuthenticatedByMatNr_NotApplied() {
+	matrNr := "03711126"
+	universityLogin := "ge25hok"
 	coursePhaseID := uuid.MustParse("4179d58a-d00d-4fa7-94a5-397bc69fab02")
 
-	application, err := GetApplicationAuthenticatedByEmail(suite.ctx, email, coursePhaseID)
+	application, err := GetApplicationAuthenticatedByMatriculationNumberAndUniversityLogin(suite.ctx, coursePhaseID, matrNr, universityLogin)
 	assert.NoError(suite.T(), err)
 	assert.NotNil(suite.T(), application)
 	assert.Equal(suite.T(), applicationDTO.StatusNotApplied, application.Status)
@@ -270,10 +271,9 @@ func (suite *ApplicationAdminServiceTestSuite) TestGetApplicationAuthenticatedBy
 }
 
 func (suite *ApplicationAdminServiceTestSuite) TestGetApplicationAuthenticatedByEmail_Unknown() {
-	email := "newstudent@example.com"
 	coursePhaseID := uuid.MustParse("4179d58a-d00d-4fa7-94a5-397bc69fab02")
 
-	application, err := GetApplicationAuthenticatedByEmail(suite.ctx, email, coursePhaseID)
+	application, err := GetApplicationAuthenticatedByMatriculationNumberAndUniversityLogin(suite.ctx, coursePhaseID, "00000000", "ab12cde")
 	assert.NoError(suite.T(), err)
 	assert.NotNil(suite.T(), application)
 	assert.Equal(suite.T(), applicationDTO.StatusNewUser, application.Status)

--- a/servers/core/db/query/students.sql
+++ b/servers/core/db/query/students.sql
@@ -36,6 +36,12 @@ RETURNING *;
 SELECT * FROM student
 WHERE email = $1 LIMIT 1;
 
+-- name: GetStudentByMatriculationNumberAndUniversityLogin :one
+SELECT * FROM student
+WHERE matriculation_number = $1
+  AND university_login = $2
+LIMIT 1;
+
 -- name: SearchStudents :many
 SELECT *
 FROM student

--- a/servers/core/db/sqlc/students.sql.go
+++ b/servers/core/db/sqlc/students.sql.go
@@ -185,6 +185,39 @@ func (q *Queries) GetStudentByEmail(ctx context.Context, email pgtype.Text) (Stu
 	return i, err
 }
 
+const getStudentByMatriculationNumberAndUniversityLogin = `-- name: GetStudentByMatriculationNumberAndUniversityLogin :one
+SELECT id, first_name, last_name, email, matriculation_number, university_login, has_university_account, gender, nationality, study_program, study_degree, current_semester, last_modified FROM student
+WHERE matriculation_number = $1
+  AND university_login = $2
+LIMIT 1
+`
+
+type GetStudentByMatriculationNumberAndUniversityLoginParams struct {
+	MatriculationNumber pgtype.Text `json:"matriculation_number"`
+	UniversityLogin     pgtype.Text `json:"university_login"`
+}
+
+func (q *Queries) GetStudentByMatriculationNumberAndUniversityLogin(ctx context.Context, arg GetStudentByMatriculationNumberAndUniversityLoginParams) (Student, error) {
+	row := q.db.QueryRow(ctx, getStudentByMatriculationNumberAndUniversityLogin, arg.MatriculationNumber, arg.UniversityLogin)
+	var i Student
+	err := row.Scan(
+		&i.ID,
+		&i.FirstName,
+		&i.LastName,
+		&i.Email,
+		&i.MatriculationNumber,
+		&i.UniversityLogin,
+		&i.HasUniversityAccount,
+		&i.Gender,
+		&i.Nationality,
+		&i.StudyProgram,
+		&i.StudyDegree,
+		&i.CurrentSemester,
+		&i.LastModified,
+	)
+	return i, err
+}
+
 const getStudentEmails = `-- name: GetStudentEmails :many
 SELECT id, email
 FROM student

--- a/servers/core/student/service.go
+++ b/servers/core/student/service.go
@@ -73,6 +73,17 @@ func GetStudentByEmail(ctx context.Context, email string) (studentDTO.Student, e
 	return studentDTO.GetStudentDTOFromDBModel(student), nil
 }
 
+func GetStudentByMatriculationNumberAndUniversityLogin(ctx context.Context, matriculation_number string, universityLogin string) (studentDTO.Student, error) {
+	student, err := StudentServiceSingleton.queries.GetStudentByMatriculationNumberAndUniversityLogin(ctx, db.GetStudentByMatriculationNumberAndUniversityLoginParams{
+		UniversityLogin:     pgtype.Text{String: universityLogin, Valid: true},
+		MatriculationNumber: pgtype.Text{String: matriculation_number, Valid: true},
+	})
+	if err != nil {
+		return studentDTO.Student{}, err
+	}
+	return studentDTO.GetStudentDTOFromDBModel(student), nil
+}
+
 func UpdateStudent(ctx context.Context, transactionQueries *db.Queries, id uuid.UUID, student studentDTO.CreateStudent) (studentDTO.Student, error) {
 	queries := utils.GetQueries(transactionQueries, &StudentServiceSingleton.queries)
 	updateStudentParams := student.GetDBModel()
@@ -88,7 +99,7 @@ func UpdateStudent(ctx context.Context, transactionQueries *db.Queries, id uuid.
 
 func CreateOrUpdateStudent(ctx context.Context, transactionQueries *db.Queries, studentObj studentDTO.CreateStudent) (studentDTO.Student, error) {
 	queries := utils.GetQueries(transactionQueries, &StudentServiceSingleton.queries)
-	studentByEmail, err := GetStudentByEmail(ctx, studentObj.Email)
+	studentByEmail, err := GetStudentByMatriculationNumberAndUniversityLogin(ctx, studentObj.MatriculationNumber, studentObj.UniversityLogin)
 	if err != nil && errors.Is(err, sql.ErrNoRows) {
 		return CreateStudent(ctx, &queries, studentObj)
 	}


### PR DESCRIPTION
Currently,  we grabbed an existing student by email. This leads to an error if a student changes their email in Tum Online. Thats why this approach tries to fetch the user by matriculationNumber and universityLogin.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for retrieving student records and application forms using matriculation number and university login instead of email.
- **Bug Fixes**
  - Improved authentication checks by requiring both matriculation number and university login for access.
- **Refactor**
  - Updated internal logic to use new student lookup methods based on matriculation number and university login.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->