### PR TITLE
`Team Allocation`: Disabling Survey After Deadline

### DIFF
--- a/clients/team_allocation_component/src/team_allocation/pages/StudentSurvey/components/SkillRanking.tsx
+++ b/clients/team_allocation_component/src/team_allocation/pages/StudentSurvey/components/SkillRanking.tsx
@@ -10,6 +10,7 @@ interface SkillRankingProps {
   skills: Skill[]
   skillRatings: Record<string, SkillLevel | undefined>
   setSkillRatings: React.Dispatch<React.SetStateAction<Record<string, SkillLevel | undefined>>>
+  disabled: boolean
 }
 
 const skillLevelOptions = [
@@ -23,6 +24,7 @@ export const SkillRanking = ({
   skills,
   skillRatings,
   setSkillRatings,
+  disabled,
 }: SkillRankingProps): JSX.Element => {
   const handleSkillRatingChange = (skillID: string, skillLevel: SkillLevel) => {
     setSkillRatings((prev) => ({ ...prev, [skillID]: skillLevel }))
@@ -55,6 +57,7 @@ export const SkillRanking = ({
                 value={skillRatings[skill.id] || ''}
                 onValueChange={(val) => handleSkillRatingChange(skill.id, val as SkillLevel)}
                 className='flex justify-between gap-2 pt-1'
+                disabled={disabled}
               >
                 {skillLevelOptions.map(({ label, value }) => (
                   <div key={value} className='flex flex-col items-center gap-1'>

--- a/clients/team_allocation_component/src/team_allocation/pages/StudentSurvey/components/SurveyForm.tsx
+++ b/clients/team_allocation_component/src/team_allocation/pages/StudentSurvey/components/SurveyForm.tsx
@@ -119,6 +119,11 @@ export const SurveyFormComponent = ({ surveyForm, surveyResponse, isStudent }: S
 
   const allSkillsSelected = surveyForm.skills.every((skill) => skillRatings[skill.id] !== undefined)
 
+  const now = dayjs()
+  const deadlineTime = dayjs(surveyForm.deadline)
+  const diff = deadlineTime.diff(now, 'second')
+  const hasDeadlinePassed = diff <= 0
+
   return (
     <div className='space-y-8'>
       {submitSuccess ? (
@@ -146,6 +151,7 @@ export const SurveyFormComponent = ({ surveyForm, surveyResponse, isStudent }: S
               teamRanking={teamRanking}
               teams={surveyForm.teams}
               setTeamRanking={setTeamRanking}
+              disabled={!isStudent || updateSurveyResponseMutation.isPending || hasDeadlinePassed}
             />
 
             {/* Skills Rating Section */}
@@ -153,6 +159,7 @@ export const SurveyFormComponent = ({ surveyForm, surveyResponse, isStudent }: S
               skills={surveyForm.skills}
               skillRatings={skillRatings}
               setSkillRatings={setSkillRatings}
+              disabled={!isStudent || updateSurveyResponseMutation.isPending || hasDeadlinePassed}
             />
 
             {submitError && (
@@ -173,7 +180,12 @@ export const SurveyFormComponent = ({ surveyForm, surveyResponse, isStudent }: S
             <Button
               type='submit'
               size='lg'
-              disabled={!isStudent || updateSurveyResponseMutation.isPending || !allSkillsSelected}
+              disabled={
+                !isStudent ||
+                updateSurveyResponseMutation.isPending ||
+                !allSkillsSelected ||
+                hasDeadlinePassed
+              }
               className='w-full sm:w-auto'
             >
               {updateSurveyResponseMutation.isPending ? (

--- a/clients/team_allocation_component/src/team_allocation/pages/StudentSurvey/components/TeamRanking.tsx
+++ b/clients/team_allocation_component/src/team_allocation/pages/StudentSurvey/components/TeamRanking.tsx
@@ -8,12 +8,14 @@ interface TeamRankingProps {
   teamRanking: string[]
   teams: Team[]
   setTeamRanking: (teamRanking: string[]) => void
+  disabled: boolean
 }
 
 export const TeamRanking = ({
   teamRanking,
   teams,
   setTeamRanking,
+  disabled,
 }: TeamRankingProps): JSX.Element => {
   const handleDragEnd = (result: DropResult) => {
     if (!result.destination) return
@@ -40,7 +42,7 @@ export const TeamRanking = ({
       </CardHeader>
       <CardContent className='pt-6'>
         <DragDropContext onDragEnd={handleDragEnd}>
-          <Droppable droppableId='teamRanking'>
+          <Droppable droppableId='teamRanking' isDropDisabled={disabled}>
             {(provided) => (
               <div className='space-y-4' {...provided.droppableProps} ref={provided.innerRef}>
                 {teamRanking.map((teamID, index) => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Survey form inputs and submission are now automatically disabled after the survey deadline has passed.
  - Skill ranking and team ranking sections can now be externally disabled, preventing changes when required.

- **Bug Fixes**
  - Prevented interaction with the survey form after the deadline, ensuring users cannot submit or modify responses late.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->