### PR TITLE
`Self Team Allocation`: Fixing Overflow

### DIFF
--- a/clients/self_team_allocation_component/src/self_team_allocation/pages/TeamAllocation/components/TeamCard.tsx
+++ b/clients/self_team_allocation_component/src/self_team_allocation/pages/TeamAllocation/components/TeamCard.tsx
@@ -55,7 +55,7 @@ export const TeamCard: React.FC<TeamCardProps> = ({
       </CardDescription>
     </CardHeader>
 
-    <CardContent className='pb-4 flex-1'>
+    <CardContent className='pb-2 flex-1'>
       {team.members.length > 0 ? (
         <ul className='space-y-2 h-[120px] overflow-y-auto'>
           {team.members.map((m, idx) => {
@@ -63,7 +63,7 @@ export const TeamCard: React.FC<TeamCardProps> = ({
             return (
               <li
                 key={idx}
-                className={`flex items-center gap-2 p-2 rounded-md ${
+                className={`flex items-center gap-2 p-1 rounded-md ${
                   isCurrent ? 'bg-primary/10 font-medium text-primary' : 'text-muted-foreground'
                 }`}
               >

--- a/clients/self_team_allocation_component/src/self_team_allocation/pages/TeamAllocation/components/TeamSelection.tsx
+++ b/clients/self_team_allocation_component/src/self_team_allocation/pages/TeamAllocation/components/TeamSelection.tsx
@@ -103,7 +103,7 @@ export const TeamSelection: React.FC<Props> = ({
           <TeamCreationDialog
             onCreate={(name) => createMutation.mutate(name)}
             teams={teams}
-            disabled={myTeam?.id !== undefined}
+            disabled={myTeam?.id !== undefined || isLecturer}
           />
           <Button
             variant='outline'


### PR DESCRIPTION
Fixing the overflow issue, when 3 team members. 
Fixed layout:
<img width="304" alt="Bildschirmfoto 2025-04-25 um 14 55 34" src="https://github.com/user-attachments/assets/8f16d148-3c12-4e8b-9ddc-bdec1d64932e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Reduced vertical spacing within team cards and member lists for a more compact layout.
- **New Features**
  - Team creation dialog is now disabled for lecturers, preventing them from creating teams.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->