### PR TITLE
`General`: Fix Loading Screen Dark Mode

### DIFF
--- a/clients/core/src/managementConsole/ManagementConsole.tsx
+++ b/clients/core/src/managementConsole/ManagementConsole.tsx
@@ -114,7 +114,11 @@ export const ManagementRoot = ({ children }: { children?: React.ReactNode }): JS
   }
 
   if (isLoading || !keycloak) {
-    return <LoadingPage />
+    return (
+      <DarkModeProvider>
+        <LoadingPage />
+      </DarkModeProvider>
+    )
   }
 
   // Check if the user has at least some Prompt rights

--- a/clients/core/src/publicPages/shared/components/AuthenticatedPageWrapper.tsx
+++ b/clients/core/src/publicPages/shared/components/AuthenticatedPageWrapper.tsx
@@ -12,6 +12,7 @@ import {
   DialogDescription,
   DialogFooter,
 } from '@/components/ui/dialog'
+import DarkModeProvider from '@/contexts/DarkModeProvider'
 import { useKeycloak } from '@core/keycloak/useKeycloak'
 
 interface NonAuthenticatedPageWrapper {
@@ -32,7 +33,11 @@ export const AuthenticatedPageWrapper = ({
   const closeLogoutDialog = () => setIsLogoutDialogOpen(false)
 
   if (!keycloak) {
-    return <LoadingPage />
+    return (
+      <DarkModeProvider>
+        <LoadingPage />
+      </DarkModeProvider>
+    )
   }
   return (
     <div className='min-h-screen bg-white flex flex-col'>


### PR DESCRIPTION
# 📝 Trying out if my PR Template looks good here:

## ✨ What is the change?

Loading screen is now also working if dark mode is enabled

## 📌 Reason for the change / Link to issue

User got a "flash of white" everytime they would reload the PROMPT website in dark mode
#502 

## 🧪 How to Test Functionality

1. Open PROMPT Dev 
2. Log in
3. Turn on Dark mode (if not already done)
4. Reload the Page

## 🖼️ Screenshots (if UI changes are included)

<!-- Include before/after screenshots if this PR involves any visual changes. -->

| Before         | After         |
| -------------- | ------------- |
| <img width="1824" alt="Bildschirmfoto 2025-05-08 um 17 55 28" src="https://github.com/user-attachments/assets/6e7f0e54-f16b-4465-b551-703b13746c7c" /> | <img width="1824" alt="Bildschirmfoto 2025-05-08 um 17 50 23" src="https://github.com/user-attachments/assets/42494943-2d2a-480c-b3e5-34d95620d193" />  |

## ⚙️ Setup / Dev Environment Instructions

1. Check if PR is still deployed to Dev instance
2. If not, deploy to dev

## ✅ PR Checklist

- [x] Tested locally or on the dev environment
- [x] Code is clean, readable, and documented
- [x] Tests added or updated (if needed)
- [x] Screenshots attached for UI changes (if any)
- [x] Documentation updated (if relevant)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved theming by ensuring the loading page supports dark mode during loading and authentication phases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->