### PR TITLE
`Assessment`: update background color for completed assessments in dark mode

### DIFF
--- a/clients/assessment_component/src/assessment/pages/AssessmentPage/components/AssessmentForm.tsx
+++ b/clients/assessment_component/src/assessment/pages/AssessmentPage/components/AssessmentForm.tsx
@@ -138,7 +138,7 @@ export const AssessmentForm = ({
                         'resize-none text-xs h-full',
                         form.formState.errors.comment &&
                           'border border-destructive focus-visible:ring-destructive',
-                        completed && 'bg-gray-100 cursor-not-allowed opacity-80',
+                        completed && 'bg-gray-100 dark:bg-gray-800 cursor-not-allowed opacity-80',
                       )}
                       disabled={completed}
                       readOnly={completed}


### PR DESCRIPTION
# 📝 Fix Darkmode Color

## ✨ What is the change?

<!-- Briefly describe what has been changed or added in this PR. -->

## 📌 Reason for the change / Link to issue
#505 

<!-- Explain why this change was made. Optionally include a link to the relevant issue or ticket. -->

## 🧪 How to Test

<!-- List the steps someone should follow to test this PR. -->

1. Go to the assessment page and fill out and finalize an assessment or click on an already finalized one
2. you can now see your comment in dark mode too

## 🖼️ Screenshots (if UI changes are included)

<!-- Include before/after screenshots if this PR involves any visual changes. -->

| Before         | After         |
| -------------- | ------------- |
| <img width="517" alt="Bildschirmfoto 2025-05-11 um 20 17 50" src="https://github.com/user-attachments/assets/f2d36440-0acd-4d01-affa-7523d7e698ec" /> | <img width="508" alt="Bildschirmfoto 2025-05-11 um 20 18 00" src="https://github.com/user-attachments/assets/53a67e7f-2b5a-4556-8900-fdedf158f90b" />  |

## ✅ PR Checklist

- [x] Tested locally or on the dev environment
- [x] Code is clean, readable, and documented
- [x] Screenshots attached for UI changes (if any)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved dark mode support for the comment textarea in completed assessments, ensuring the background adapts appropriately to both light and dark themes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->