### PR TITLE
`General`: Enhance Breadcrumb hover animation to be point instead of cursor

### DIFF
--- a/clients/core/src/managementConsole/layout/Breadcrumbs/Breadcrumbs.tsx
+++ b/clients/core/src/managementConsole/layout/Breadcrumbs/Breadcrumbs.tsx
@@ -89,7 +89,9 @@ export const Breadcrumbs: React.FC = () => {
               {index === breadcrumbList.length - 1 ? (
                 <BreadcrumbPage>{crumb.title}</BreadcrumbPage>
               ) : (
-                <BreadcrumbLink onClick={() => navigate(crumb.path)}>{crumb.title}</BreadcrumbLink>
+                <BreadcrumbLink style={{ cursor: 'pointer' }} onClick={() => navigate(crumb.path)}>
+                  {crumb.title}
+                </BreadcrumbLink>
               )}
             </BreadcrumbItem>
           </React.Fragment>


### PR DESCRIPTION
# 📝 Pull Request Template

Use this template to provide all necessary information for reviewing and testing your changes.

## ✨ What is the change?

<!-- Briefly describe what has been changed or added in this PR. -->

Change the hover animation to be point instead of cursor

## 📌 Reason for the change / Link to issue

<!-- Explain why this change was made. Optionally include a link to the relevant issue or ticket. -->

closes #439 

## 🧪 How to Test

<!-- List the steps someone should follow to test this PR. -->

1. Go to a page with breadcrums
2. check if the animation is point and not cursor

## ✅ PR Checklist

- [x] Tested locally or on the dev environment
- [x] Code is clean, readable, and documented
- [x] Screenshots attached for UI changes (if any)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated breadcrumb links to display a pointer cursor, improving the visual indication that they are clickable (except for the last breadcrumb item).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->