### PR TITLE
`General`: Only regenerate API spec on change in the respective server

### DIFF
--- a/.github/workflows/generate-api-spec.yml
+++ b/.github/workflows/generate-api-spec.yml
@@ -7,8 +7,31 @@ on:
   workflow_dispatch:
 
 jobs:
+  detect-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      core-changed: ${{ steps.changes.outputs.core }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: changes
+        with:
+          filters: |
+            core:
+              - 'servers/core/**'
+
   generate-api-spec:
     runs-on: ubuntu-latest
+    needs: detect-changes
+    if: |
+      needs.detect-changes.outputs.core-changed       == 'true'
+    strategy:
+      matrix:
+        directory:
+          - ${{ needs.detect-changes.outputs.core-changed       == 'true' && 'core'       || '' }}
+        exclude:
+          - directory: ""
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -16,18 +39,20 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: "1.22"
 
       - name: Install swag
-        run: go install github.com/swaggo/swag/cmd/swag@latest
-
-      - name: Generate API spec
         run: |
-          cd servers/core
-          $(go env GOPATH)/bin/swag init --output docs/api --parseDependency --parseInternal
+          go install github.com/swaggo/swag/cmd/swag@latest
+          echo "${HOME}/go/bin" >> $GITHUB_PATH
+
+      - name: Generate API spec for ${{ matrix.directory }}
+        run: |
+          cd servers/${{ matrix.directory }}
+          swag init --output docs/api --parseDependency --parseInternal
 
       - name: Upload API spec artifact
         uses: actions/upload-artifact@v4
         with:
-          name: api-spec
-          path: servers/core/docs/api/
+          name: api-spec-${{ matrix.directory }}
+          path: servers/${{ matrix.directory }}/docs/api/


### PR DESCRIPTION
# 📝 `General`: Only regenerate API spec on change in the respective server

## ✨ What is the change?

<!-- Briefly describe what has been changed or added in this PR. -->

Adapt the generate-api-spec workflow to incorporate a detect changes step. 

## 📌 Reason for the change / Link to issue

closes #567 

<!-- Explain why this change was made. Optionally include a link to the relevant issue or ticket. -->

## 🧪 How to Test

<!-- List the steps someone should follow to test this PR. -->

1. Check if the workflow runs through successfully and only rebuilds API spec on change

## ✅ PR Checklist

- [x] Tested locally or on the dev environment
- [x] Code is clean, readable, and documented
- [x] Documentation updated (if relevant)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved automation to only generate API specifications when relevant source code changes are detected.
  - Updated the workflow environment to use Go 1.22.
  - Enhanced artifact naming and generation steps for better flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->