### PR TITLE
`Core`: Fix Semester Tag Input Handling to only allow lowercase and numbers

### DIFF
--- a/clients/core/src/managementConsole/courseOverview/AddingCourse/AddCourseProperties.tsx
+++ b/clients/core/src/managementConsole/courseOverview/AddingCourse/AddCourseProperties.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect } from 'react'
+import type React from 'react'
+import { useEffect } from 'react'
 import {
   Button,
   Input,
@@ -16,7 +17,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@tumaet/prompt-ui-components'
-import { courseFormSchema, CourseFormValues } from '@core/validations/course'
+import { courseFormSchema, type CourseFormValues } from '@core/validations/course'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { useForm } from 'react-hook-form'
 import { CourseType, CourseTypeDetails } from '@tumaet/prompt-shared-state'
@@ -56,6 +57,11 @@ export const AddCourseProperties: React.FC<AddCoursePropertiesProps> = ({
       form.setValue('ects', ectsValue as number, { shouldValidate: true })
     }
   }, [selectedCourseType, form])
+
+  const handleSemesterTagChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const filteredValue = e.target.value.toLowerCase().replace(/[^a-z0-9]/g, '')
+    form.setValue('semesterTag', filteredValue, { shouldValidate: true })
+  }
 
   return (
     <Form {...form}>
@@ -142,9 +148,16 @@ export const AddCourseProperties: React.FC<AddCoursePropertiesProps> = ({
             <FormItem>
               <FormLabel>Semester Tag</FormLabel>
               <FormControl>
-                <Input placeholder='Enter a semester tag' {...field} className='w-full' />
+                <Input
+                  placeholder='Enter a semester tag'
+                  value={field.value}
+                  onChange={handleSemesterTagChange}
+                  className='w-full'
+                />
               </FormControl>
-              <FormDescription>e.g. ios2425 or WS24/25</FormDescription>
+              <FormDescription>
+                e.g. ios2425 or ws2425 (lowercase letters and numbers only)
+              </FormDescription>
               <FormMessage />
             </FormItem>
           )}


### PR DESCRIPTION
# 📝 Input Handling Semester Tag

## ✨ What is the change?

The input field now forces the user to only use lowercase and numbers in the semester tag

## 📌 Reason for the change / Link to issue

#577 

## 🧪 How to Test

1. Go on PROMPT
2. Click on '+' to create new course
3. Test around with the semester tag input

## 🖼️ Screenshots (if UI changes are included)

| Before         | After         |
| -------------- | ------------- |
| <img width="589" alt="Bildschirmfoto 2025-06-07 um 12 42 24" src="https://github.com/user-attachments/assets/33462887-32e6-4e34-889e-7fd8b26fd9ca" /> | <img width="574" alt="Bildschirmfoto 2025-06-07 um 12 42 33" src="https://github.com/user-attachments/assets/a5642937-cbc6-4d6e-89aa-2883a214284f" /> |

## ✅ PR Checklist

- [ ] Tested locally
- [ ] Code is clean, readable, and documented
- [ ] Screenshots attached for UI changes
