### PR TITLE
`General`: Add port mappings for database services in docker-compose

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -203,6 +203,8 @@ services:
       interval: 5s
       timeout: 5s
       retries: 5
+    ports:
+      - "127.0.0.1:5432:5432"
     networks:
       - prompt-network
 
@@ -221,6 +223,8 @@ services:
       interval: 5s
       timeout: 5s
       retries: 5
+    ports:
+      - "127.0.0.1:5433:5432"
     networks:
       - prompt-network
 
@@ -239,9 +243,11 @@ services:
       interval: 5s
       timeout: 5s
       retries: 5
+    ports:
+      - "127.0.0.1:5434:5432"
     networks:
       - prompt-network
-    
+
   db-self-team-allocation:
     image: "postgres:15.2-alpine"
     container_name: prompt-db-self-team-allocation
@@ -257,6 +263,8 @@ services:
       interval: 5s
       timeout: 5s
       retries: 5
+    ports:
+      - "127.0.0.1:5436:5432"
     networks:
       - prompt-network
 
@@ -275,6 +283,8 @@ services:
       interval: 5s
       timeout: 5s
       retries: 5
+    ports:
+      - "127.0.0.1:5435:5432"
     networks:
       - prompt-network
 


### PR DESCRIPTION
# 📝 Add port mappings for database services in docker-compose

## ✨ What is the change?

<!-- Briefly describe what has been changed or added in this PR. -->
Add port mappings for database services in docker-compose


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated production configuration to allow local access to each database instance on unique ports, improving connectivity for database services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->