### PR TITLE
`Team Allocation`: Add CourseEditor role to allocation and team routes

### DIFF
--- a/servers/team_allocation/allocation/router.go
+++ b/servers/team_allocation/allocation/router.go
@@ -12,8 +12,8 @@ import (
 func setupAllocationRouter(routerGroup *gin.RouterGroup, authMiddleware func(allowedRoles ...string) gin.HandlerFunc) {
 	allocationRouter := routerGroup.Group("/allocation")
 
-	allocationRouter.GET("", authMiddleware(promptSDK.PromptAdmin, promptSDK.CourseLecturer), getAllAllocations)
-	allocationRouter.GET("/:courseParticipationID", authMiddleware(promptSDK.PromptAdmin, promptSDK.CourseLecturer), getAllocationByCourseParticipationID)
+	allocationRouter.GET("", authMiddleware(promptSDK.PromptAdmin, promptSDK.CourseLecturer, promptSDK.CourseEditor), getAllAllocations)
+	allocationRouter.GET("/:courseParticipationID", authMiddleware(promptSDK.PromptAdmin, promptSDK.CourseLecturer, promptSDK.CourseEditor), getAllocationByCourseParticipationID)
 }
 
 func getAllAllocations(c *gin.Context) {

--- a/servers/team_allocation/team/router.go
+++ b/servers/team_allocation/team/router.go
@@ -13,13 +13,13 @@ import (
 func setupTeamRouter(routerGroup *gin.RouterGroup, authMiddleware func(allowedRoles ...string) gin.HandlerFunc) {
 	teamRouter := routerGroup.Group("/team")
 
-	teamRouter.GET("", authMiddleware(promptSDK.PromptAdmin, promptSDK.CourseLecturer), getAllTeams)
+	teamRouter.GET("", authMiddleware(promptSDK.PromptAdmin, promptSDK.CourseLecturer, promptSDK.CourseEditor), getAllTeams)
 	teamRouter.POST("", authMiddleware(promptSDK.PromptAdmin, promptSDK.CourseLecturer), createTeams)
 	teamRouter.PUT("/:teamID", authMiddleware(promptSDK.PromptAdmin, promptSDK.CourseLecturer), updateTeam)
 	teamRouter.DELETE("/:teamID", authMiddleware(promptSDK.PromptAdmin, promptSDK.CourseLecturer), deleteTeam)
 
 	// this is required to comply with the inter phase communication protocol
-	teamRouter.GET("/:teamID", authMiddleware(promptSDK.PromptAdmin, promptSDK.CourseLecturer), getTeamByID)
+	teamRouter.GET("/:teamID", authMiddleware(promptSDK.PromptAdmin, promptSDK.CourseLecturer, promptSDK.CourseEditor), getTeamByID)
 }
 
 func getAllTeams(c *gin.Context) {


### PR DESCRIPTION
# 📝 Add CourseEditor role to allocation and team routes

## ✨ What is the change?

<!-- Briefly describe what has been changed or added in this PR. -->
Add CourseEditor role to allocation and team routes

## 📌 Reason for the change / Link to issue

<!-- Explain why this change was made. Optionally include a link to the relevant issue or ticket. -->
Editors in the assessment (PLs) can't access the teamAllocations due to missing access rights to the teams and allocation endpoint in the TeamAllocation Server. This leads to internal server errors when fetching teams and allocations during the inter course phase communication to retrieve team data. 

## 🧪 How to Test

<!-- List the steps someone should follow to test this PR. -->

1. Use Editor Rights
2. Open the Team Overview in the assessment page. 

## ✅ PR Checklist

- [x] Tested locally or on the dev environment
- [x] Code is clean, readable, and documented
- [x] Documentation updated (if relevant)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded access to allocation and team information endpoints to users with the Course Editor role, in addition to existing roles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->