### PR TITLE
`Team Allocation`: Change getAllTeams endpoint to return teams with team members names

### DIFF
--- a/clients/team_allocation_component/src/team_allocation/interfaces/studentNameUpdateRequest.ts
+++ b/clients/team_allocation_component/src/team_allocation/interfaces/studentNameUpdateRequest.ts
@@ -1,0 +1,4 @@
+export type StudentNameUpdateRequest = {
+  coursePhaseID: string
+  studentNames: { [courseParticipationID: string]: string } // key: UUID string, value: full name
+}

--- a/clients/team_allocation_component/src/team_allocation/interfaces/team.ts
+++ b/clients/team_allocation_component/src/team_allocation/interfaces/team.ts
@@ -1,4 +1,10 @@
 export type Team = {
   id: string
   name: string
+  members: TeamMember[]
+}
+
+export type TeamMember = {
+  courseParticipationID: string
+  studentName: string
 }

--- a/clients/team_allocation_component/src/team_allocation/network/mutations/addStudentNamesToTeams.ts
+++ b/clients/team_allocation_component/src/team_allocation/network/mutations/addStudentNamesToTeams.ts
@@ -1,0 +1,21 @@
+import { teamAllocationAxiosInstance } from '../teamAllocationServerConfig'
+import { StudentNameUpdateRequest } from '../../interfaces/studentNameUpdateRequest'
+
+export const addStudentNamesToTeams = async (
+  studentNames: StudentNameUpdateRequest,
+): Promise<void> => {
+  try {
+    await teamAllocationAxiosInstance.post(
+      `/team-allocation/api/course_phase/${studentNames.coursePhaseID}/team/student-names`,
+      studentNames,
+      {
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      },
+    )
+  } catch (err) {
+    console.error(err)
+    throw err
+  }
+}

--- a/clients/team_allocation_component/src/team_allocation/pages/Participants/ParticipantsPage.tsx
+++ b/clients/team_allocation_component/src/team_allocation/pages/Participants/ParticipantsPage.tsx
@@ -106,7 +106,9 @@ export const ParticipantsPage = (): JSX.Element => {
       ),
     }
 
-    void addStudentNamesToTeams(requestPayload)
+    void addStudentNamesToTeams(requestPayload).catch((error) => {
+      console.error('Failed to update student names:', error)
+    })
   }, [coursePhaseParticipations, phaseId])
 
   const isError = isParticipationsError || isTeamsError || isTeamAllocationsError

--- a/clients/team_allocation_component/src/team_allocation/pages/Participants/ParticipantsPage.tsx
+++ b/clients/team_allocation_component/src/team_allocation/pages/Participants/ParticipantsPage.tsx
@@ -11,6 +11,8 @@ import { useMemo } from 'react'
 import { ExtraParticipationTableColumn } from '@/components/pages/CoursePhaseParticpationsTable/interfaces/ExtraParticipationTableColumn'
 import { getTeamAllocations } from '../../network/queries/getTeamAllocations'
 import { Allocation } from '../../interfaces/allocation'
+import { useEffect } from 'react'
+import { addStudentNamesToTeams } from '../../network/mutations/addStudentNamesToTeams'
 
 export const ParticipantsPage = (): JSX.Element => {
   const { phaseId } = useParams<{ phaseId: string }>()
@@ -87,6 +89,25 @@ export const ParticipantsPage = (): JSX.Element => {
     refetchTeams()
     refetchTeamAllocations()
   }
+
+  useEffect(() => {
+    if (!coursePhaseParticipations?.participations?.length || !phaseId) return
+
+    const requestPayload = {
+      coursePhaseID: phaseId,
+      studentNames: coursePhaseParticipations.participations.reduce(
+        (acc, p) => {
+          if (p.student?.firstName && p.student?.lastName) {
+            acc[p.courseParticipationID] = `${p.student.firstName} ${p.student.lastName}`
+          }
+          return acc
+        },
+        {} as Record<string, string>,
+      ),
+    }
+
+    void addStudentNamesToTeams(requestPayload)
+  }, [coursePhaseParticipations, phaseId])
 
   const isError = isParticipationsError || isTeamsError || isTeamAllocationsError
   const isPending = isCoursePhaseParticipationsPending || isTeamsPending || isTeamAllocationsPending

--- a/servers/team_allocation/db/migration/0004_add_student_names_to_allocations.up.sql
+++ b/servers/team_allocation/db/migration/0004_add_student_names_to_allocations.up.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+ALTER TABLE allocations
+ADD COLUMN student_full_name TEXT NOT NULL DEFAULT '';
+
+COMMIT;

--- a/servers/team_allocation/db/query/allocation.sql
+++ b/servers/team_allocation/db/query/allocation.sql
@@ -4,23 +4,25 @@ FROM allocations a
 WHERE a.course_phase_id = $1;
 
 -- name: CreateOrUpdateAllocation :exec
-INSERT INTO allocations AS a (id,
-                              course_participation_id,
-                              team_id,
-                              course_phase_id,
-                              created_at,
-                              updated_at)
-VALUES ($1,
-        $2,
-        $3,
-        $4,
-        CURRENT_TIMESTAMP,
-        CURRENT_TIMESTAMP)
+INSERT INTO allocations AS a (
+  id,
+  course_participation_id,
+  team_id,
+  course_phase_id,
+  created_at,
+  updated_at
+) VALUES (
+  $1,
+  $2,
+  $3,
+  $4,
+  CURRENT_TIMESTAMP,
+  CURRENT_TIMESTAMP
+)
 ON CONFLICT ON CONSTRAINT allocations_participation_phase_uk
-    DO UPDATE
-    SET team_id    = EXCLUDED.team_id,
-        updated_at = CURRENT_TIMESTAMP;
-
+DO UPDATE
+SET team_id = EXCLUDED.team_id,
+    updated_at = CURRENT_TIMESTAMP;
 
 -- name: DeleteAllocationsByPhase :exec
 DELETE
@@ -32,6 +34,7 @@ WHERE a.team_id = t.id
 -- name: GetAllocationForStudent :one
 SELECT id,
        course_participation_id,
+       student_full_name,
        team_id,
        course_phase_id,
        created_at,
@@ -47,3 +50,87 @@ FROM allocations
 WHERE course_phase_id = $1
 GROUP BY team_id
 ORDER BY team_id;
+
+-- name: GetTeamsWithStudentNames :many
+SELECT
+  t.id,
+  t.name,
+  COALESCE(
+    jsonb_agg(
+      jsonb_build_object(
+        'courseParticipationID', a.course_participation_id,
+        'studentName',           a.student_full_name
+      )
+      ORDER BY a.student_full_name
+    ) FILTER (WHERE a.id IS NOT NULL),
+    '[]'::jsonb
+  )::jsonb AS team_members
+FROM
+  team t
+LEFT JOIN
+  allocations a
+  ON t.id = a.team_id
+WHERE
+  t.course_phase_id = $1
+GROUP BY
+  t.id, t.name
+ORDER BY
+  t.name;
+
+-- name: GetTeamWithStudentNamesByID :one
+SELECT
+  t.id,
+  t.name,
+  COALESCE(
+    jsonb_agg(
+      jsonb_build_object(
+        'courseParticipationID', a.course_participation_id,
+        'studentName',           a.student_full_name
+      )
+      ORDER BY a.student_full_name
+    ) FILTER (WHERE a.id IS NOT NULL),
+    '[]'::jsonb
+  )::jsonb AS team_members
+FROM
+  team t
+LEFT JOIN
+  allocations a
+  ON t.id = a.team_id
+WHERE
+  t.id = $1
+GROUP BY
+  t.id, t.name;
+
+-- name: GetTeamWithStudentNamesByTeamID :one
+SELECT
+  t.id,
+  t.name,
+  COALESCE(
+    jsonb_agg(
+      jsonb_build_object(
+        'courseParticipationID', a.course_participation_id,
+        'studentName',           a.student_full_name
+      )
+      ORDER BY a.student_full_name
+    ) FILTER (WHERE a.id IS NOT NULL),
+    '[]'::jsonb
+  )::jsonb AS team_members
+FROM
+  team t
+LEFT JOIN
+  allocations a
+  ON t.id = a.team_id
+WHERE
+  t.course_phase_id = $1
+  AND t.id = $2
+GROUP BY
+  t.id, t.name
+ORDER BY
+  t.name;
+
+-- name: UpdateStudentFullNameForAllocation :exec
+UPDATE allocations
+SET student_full_name = $1,
+    updated_at = CURRENT_TIMESTAMP
+WHERE course_participation_id = $2
+  AND course_phase_id = $3;

--- a/servers/team_allocation/db/query/team.sql
+++ b/servers/team_allocation/db/query/team.sql
@@ -25,3 +25,80 @@ AND course_phase_id = $2; -- ensuring to update only teams in the authenticated 
 DELETE FROM team
 WHERE id = $1
 AND course_phase_id = $2; -- ensuring to delete only teams in the authenticated course_phase
+
+-- name: GetAllocationsWithStudentNames :many
+SELECT
+  t.id,
+  t.name,
+  COALESCE(
+    jsonb_agg(
+      jsonb_build_object(
+        'courseParticipationID', a.course_participation_id,
+        'studentName',           a.student_full_name
+      )
+      ORDER BY a.student_full_name
+    ) FILTER (WHERE a.id IS NOT NULL),
+    '[]'::jsonb
+  )::jsonb AS team_members
+FROM
+  team t
+LEFT JOIN
+  allocations a
+  ON t.id = a.team_id
+WHERE
+  t.course_phase_id = $1
+GROUP BY
+  t.id, t.name
+ORDER BY
+  t.name;
+
+-- name: GetAllocationsWithStudentNamesByID :one
+SELECT
+  t.id,
+  t.name,
+  COALESCE(
+    jsonb_agg(
+      jsonb_build_object(
+        'courseParticipationID', a.course_participation_id,
+        'studentName',           a.student_full_name
+      )
+      ORDER BY a.student_full_name
+    ) FILTER (WHERE a.id IS NOT NULL),
+    '[]'::jsonb
+  )::jsonb AS team_members
+FROM
+  team t
+LEFT JOIN
+  allocations a
+  ON t.id = a.team_id
+WHERE
+  t.id = $1
+GROUP BY
+  t.id, t.name;
+
+-- name: GetAllocationWithStudentNamesByTeamID :one
+SELECT
+  t.id,
+  t.name,
+  COALESCE(
+    jsonb_agg(
+      jsonb_build_object(
+        'courseParticipationID', a.course_participation_id,
+        'studentName',           a.student_full_name
+      )
+      ORDER BY a.student_full_name
+    ) FILTER (WHERE a.id IS NOT NULL),
+    '[]'::jsonb
+  )::jsonb AS team_members
+FROM
+  team t
+LEFT JOIN
+  allocations a
+  ON t.id = a.team_id
+WHERE
+  t.course_phase_id = $1
+  AND t.id = $2
+GROUP BY
+  t.id, t.name
+ORDER BY
+  t.name;

--- a/servers/team_allocation/db/sqlc/models.go
+++ b/servers/team_allocation/db/sqlc/models.go
@@ -63,6 +63,7 @@ type Allocation struct {
 	CoursePhaseID         uuid.UUID        `json:"course_phase_id"`
 	CreatedAt             pgtype.Timestamp `json:"created_at"`
 	UpdatedAt             pgtype.Timestamp `json:"updated_at"`
+	StudentFullName       string           `json:"student_full_name"`
 }
 
 type Skill struct {

--- a/servers/team_allocation/team/router.go
+++ b/servers/team_allocation/team/router.go
@@ -18,6 +18,8 @@ func setupTeamRouter(routerGroup *gin.RouterGroup, authMiddleware func(allowedRo
 	teamRouter.PUT("/:teamID", authMiddleware(promptSDK.PromptAdmin, promptSDK.CourseLecturer), updateTeam)
 	teamRouter.DELETE("/:teamID", authMiddleware(promptSDK.PromptAdmin, promptSDK.CourseLecturer), deleteTeam)
 
+	teamRouter.POST("/student-names", authMiddleware(promptSDK.PromptAdmin, promptSDK.CourseLecturer), addStudentNamesToTeams)
+
 	// this is required to comply with the inter phase communication protocol
 	teamRouter.GET("/:teamID", authMiddleware(promptSDK.PromptAdmin, promptSDK.CourseLecturer, promptSDK.CourseEditor), getTeamByID)
 }
@@ -137,4 +139,20 @@ func deleteTeam(c *gin.Context) {
 
 func handleError(c *gin.Context, statusCode int, err error) {
 	c.JSON(statusCode, gin.H{"error": err.Error()})
+}
+
+func addStudentNamesToTeams(c *gin.Context) {
+	var req teamDTO.StudentNameUpdateRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		handleError(c, http.StatusBadRequest, err)
+		return
+	}
+
+	if err := AddStudentNamesToAllocations(c, req); err != nil {
+		log.Error("Error adding student names to allocations: ", err)
+		handleError(c, http.StatusInternalServerError, err)
+		return
+	}
+
+	c.Status(http.StatusOK)
 }

--- a/servers/team_allocation/team/service.go
+++ b/servers/team_allocation/team/service.go
@@ -97,3 +97,17 @@ func DeleteTeam(ctx context.Context, coursePhaseID, teamID uuid.UUID) error {
 	}
 	return nil
 }
+
+func AddStudentNamesToAllocations(ctx context.Context, req teamDTO.StudentNameUpdateRequest) error {
+	for participationID, fullName := range req.StudentNamesPerID {
+		err := TeamsServiceSingleton.queries.UpdateStudentFullNameForAllocation(ctx, db.UpdateStudentFullNameForAllocationParams{
+			StudentFullName:       fullName,
+			CourseParticipationID: participationID,
+			CoursePhaseID:         req.CoursePhaseID,
+		})
+		if err != nil {
+			return fmt.Errorf("failed to update name for participation ID %s: %w", participationID, err)
+		}
+	}
+	return nil
+}

--- a/servers/team_allocation/team/service.go
+++ b/servers/team_allocation/team/service.go
@@ -21,12 +21,17 @@ type TeamsService struct {
 var TeamsServiceSingleton *TeamsService
 
 func GetAllTeams(ctx context.Context, coursePhaseID uuid.UUID) ([]teamDTO.Team, error) {
-	dbTeams, err := TeamsServiceSingleton.queries.GetTeamsByCoursePhase(ctx, coursePhaseID)
+	dbTeams, err := TeamsServiceSingleton.queries.GetAllocationsWithStudentNames(ctx, coursePhaseID)
 	if err != nil {
 		log.Error("could not get the teams from the database: ", err)
 		return nil, errors.New("could not get the teams from the database")
 	}
-	return teamDTO.GetTeamDTOsFromDBModels(dbTeams), nil
+	dtos, err := teamDTO.GetTeamWithFullNameDTOsFromDBModels(dbTeams)
+	if err != nil {
+		log.Error("could not get the teams from the database: ", err)
+		return nil, errors.New("could not get the teams from the database")
+	}
+	return dtos, nil
 }
 
 func GetTeamByID(ctx context.Context, coursePhaseID uuid.UUID, teamID uuid.UUID) (teamDTO.Team, error) {

--- a/servers/team_allocation/team/teamDTO/studentNameUpdateRequest.go
+++ b/servers/team_allocation/team/teamDTO/studentNameUpdateRequest.go
@@ -1,0 +1,8 @@
+package teamDTO
+
+import "github.com/google/uuid"
+
+type StudentNameUpdateRequest struct {
+	CoursePhaseID     uuid.UUID            `json:"coursePhaseID"`
+	StudentNamesPerID map[uuid.UUID]string `json:"studentNames"` // courseParticipationID -> fullName
+}

--- a/servers/team_allocation/team/teamDTO/team.go
+++ b/servers/team_allocation/team/teamDTO/team.go
@@ -33,7 +33,7 @@ func GetTeamDTOsFromDBModels(dbTeams []db.Team) []Team {
 	return teams
 }
 
-func GetAllocationDTOFromDBModel(dbTeam db.GetAllocationsWithStudentNamesRow) (Team, error) {
+func GetTeamDTOFromAllocationRow(dbTeam db.GetAllocationsWithStudentNamesRow) (Team, error) {
 	var members []TeamMember
 	// unmarshal the JSON blob into your slice of structs
 	if err := json.Unmarshal(dbTeam.TeamMembers, &members); err != nil {
@@ -64,7 +64,7 @@ func GetTeamWithFullNamesByIdDTOFromDBModel(dbTeam db.GetTeamWithStudentNamesByT
 func GetTeamWithFullNameDTOsFromDBModels(dbTeams []db.GetAllocationsWithStudentNamesRow) ([]Team, error) {
 	teams := make([]Team, 0, len(dbTeams))
 	for _, dbTeam := range dbTeams {
-		t, err := GetAllocationDTOFromDBModel(dbTeam)
+		t, err := GetTeamDTOFromAllocationRow(dbTeam)
 		if err != nil {
 			// handle or log error; skip or abort as you preferable
 			return nil, err

--- a/servers/team_allocation/team/teamDTO/team.go
+++ b/servers/team_allocation/team/teamDTO/team.go
@@ -1,13 +1,21 @@
 package teamDTO
 
 import (
+	"encoding/json"
+
 	"github.com/google/uuid"
 	db "github.com/ls1intum/prompt2/servers/team_allocation/db/sqlc"
 )
 
 type Team struct {
-	ID   uuid.UUID `json:"id"`
-	Name string    `json:"name"`
+	ID      uuid.UUID    `json:"id"`
+	Name    string       `json:"name"`
+	Members []TeamMember `json:"members"`
+}
+
+type TeamMember struct {
+	CourseParticipationID uuid.UUID `json:"courseParticipationID"`
+	StudentName           string    `json:"studentName"`
 }
 
 func GetTeamDTOFromDBModel(dbTeam db.Team) Team {
@@ -23,4 +31,45 @@ func GetTeamDTOsFromDBModels(dbTeams []db.Team) []Team {
 		teams = append(teams, GetTeamDTOFromDBModel(dbTeam))
 	}
 	return teams
+}
+
+func GetAllocationDTOFromDBModel(dbTeam db.GetAllocationsWithStudentNamesRow) (Team, error) {
+	var members []TeamMember
+	// unmarshal the JSON blob into your slice of structs
+	if err := json.Unmarshal(dbTeam.TeamMembers, &members); err != nil {
+		return Team{}, err
+	}
+
+	return Team{
+		ID:      dbTeam.ID,
+		Name:    dbTeam.Name,
+		Members: members,
+	}, nil
+}
+
+func GetTeamWithFullNamesByIdDTOFromDBModel(dbTeam db.GetTeamWithStudentNamesByTeamIDRow) (Team, error) {
+	var members []TeamMember
+	// unmarshal the JSON blob into your slice of structs
+	if err := json.Unmarshal(dbTeam.TeamMembers, &members); err != nil {
+		return Team{}, err
+	}
+
+	return Team{
+		ID:      dbTeam.ID,
+		Name:    dbTeam.Name,
+		Members: members,
+	}, nil
+}
+
+func GetTeamWithFullNameDTOsFromDBModels(dbTeams []db.GetAllocationsWithStudentNamesRow) ([]Team, error) {
+	teams := make([]Team, 0, len(dbTeams))
+	for _, dbTeam := range dbTeams {
+		t, err := GetAllocationDTOFromDBModel(dbTeam)
+		if err != nil {
+			// handle or log error; skip or abort as you preferable
+			return nil, err
+		}
+		teams = append(teams, t)
+	}
+	return teams, nil
 }


### PR DESCRIPTION
# 📝 Change endpoint to return teams with members names

## ✨ What is the change?

- Changed the `getAllTeams` endpoint to return team members names with the teams
- As soon as you go onto the _Participants_ subpage in the Team Allocation component, the names of the students are automatically updated in the DB

## 📌 Reason for the change / Link to issue

#656 

## 🧪 How to Test

<!-- List the steps someone should follow to test this PR. -->

1. Step 1
2. Step 2
3. ...

## 🖼️ Screenshots (if UI changes are included)

## ✅ PR Checklist

- [x] Tested locally or on the dev environment
- [x] Code is clean, readable, and documented
- [x] Tests added or updated (if needed)
- [x] Screenshots attached for UI changes (if any)
- [x] Documentation updated (if relevant)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Teams now display members with full names and participation IDs.
  * Bulk updating of student names per course phase is supported.
  * Student full names are shown consistently in team and allocation views.

* **Bug Fixes**
  * Improved accuracy and consistency of student name display within teams.

* **Backend Improvements**
  * Added API endpoint for updating student names in teams.
  * Enhanced database schema and queries to store and retrieve student full names in allocations and teams.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->