### PR TITLE
`Matching`: Rename to Participants subpage

### DIFF
--- a/clients/matching_component/routes/index.tsx
+++ b/clients/matching_component/routes/index.tsx
@@ -2,7 +2,7 @@ import { DataExportPage } from '../src/matching/pages/DataExport/DataExportPage'
 import { MatchingOverviewPage } from '../src/matching/MatchingOverviewPage'
 import { ExtendedRouteObject } from '@/interfaces/extendedRouteObject'
 import { Role } from '@tumaet/prompt-shared-state'
-import { ParticipantsTablePage } from '../src/matching/pages/ParticipantsTable/ParticipantsTablePage'
+import { MatchingParticipantsPage } from '../src/matching/pages/MatchingParticipantsPage/MatchingParticipantsPage'
 import { DataImportPage } from '../src/matching/pages/DataImport/DataImportPage'
 
 const routes: ExtendedRouteObject[] = [
@@ -23,7 +23,7 @@ const routes: ExtendedRouteObject[] = [
   },
   {
     path: '/participants',
-    element: <ParticipantsTablePage />,
+    element: <MatchingParticipantsPage />,
     requiredPermissions: [Role.PROMPT_ADMIN, Role.COURSE_LECTURER],
   },
   // Add more routes here as needed

--- a/clients/matching_component/sidebar/index.tsx
+++ b/clients/matching_component/sidebar/index.tsx
@@ -3,7 +3,7 @@ import { SidebarMenuItemProps } from '@/interfaces/sidebar'
 import { Role } from '@tumaet/prompt-shared-state'
 
 const sidebarItems: SidebarMenuItemProps = {
-  title: 'TemplateComponent',
+  title: 'Matching',
   icon: <Puzzle />,
   requiredPermissions: [Role.PROMPT_ADMIN, Role.COURSE_LECTURER],
   goToPath: '',

--- a/clients/matching_component/src/matching/pages/MatchingParticipantsPage/MatchingParticipantsPage.tsx
+++ b/clients/matching_component/src/matching/pages/MatchingParticipantsPage/MatchingParticipantsPage.tsx
@@ -6,7 +6,7 @@ import { CoursePhaseParticipationsWithResolution } from '@tumaet/prompt-shared-s
 import { ErrorPage, ManagementPageHeader } from '@tumaet/prompt-ui-components'
 import { CoursePhaseParticipationsTablePage } from '@/components/pages/CoursePhaseParticpationsTable/CoursePhaseParticipationsTablePage'
 
-export const ParticipantsTablePage = (): JSX.Element => {
+export const MatchingParticipantsPage = (): JSX.Element => {
   const { phaseId } = useParams<{ phaseId: string }>()
 
   const {

--- a/clients/matching_component/src/matching/pages/ParticipantsTable/ParticipantsTablePage.tsx
+++ b/clients/matching_component/src/matching/pages/ParticipantsTable/ParticipantsTablePage.tsx
@@ -21,7 +21,7 @@ export const ParticipantsTablePage = (): JSX.Element => {
 
   return (
     <div>
-      <ManagementPageHeader>Course Phase Participants</ManagementPageHeader>
+      <ManagementPageHeader>Matching Participants</ManagementPageHeader>
       {isParticipationsError ? (
         <ErrorPage onRetry={refetchCoursePhaseParticipations} />
       ) : isCoursePhaseParticipationsPending ? (


### PR DESCRIPTION
# 📝 Matching: Rename to Participants subpage

## 📌 Reason for the change / Link to issue

#673 

## 🧪 How to Test

1. Go to Matching phase
2. Look at Participants page

## 🖼️ Screenshots (if UI changes are included)

| Before         | After         |
| -------------- | ------------- |
| <img width="1824" height="1167" alt="Bildschirmfoto 2025-07-11 um 18 15 38" src="https://github.com/user-attachments/assets/f5cfb7aa-e9cf-4e39-b1c7-73ca9d3797c1" /> | <img width="1824" height="1167" alt="Bildschirmfoto 2025-07-11 um 18 15 59" src="https://github.com/user-attachments/assets/f5e17808-88e5-4d2a-ac04-48146a34d133" /> |

## ✅ PR Checklist

- [x] Tested locally or on the dev environment
- [x] Code is clean, readable, and documented
- [x] Tests added or updated (if needed)
- [x] Screenshots attached for UI changes (if any)
- [x] Documentation updated (if relevant)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated sidebar menu item title from "TemplateComponent" to "Matching".
  * Changed header text on the participants page from "Course Phase Participants" to "Matching Participants".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->