### PR TITLE
`Assessment`: Rename to Participants subpage

### DIFF
--- a/clients/assessment_component/routes/index.tsx
+++ b/clients/assessment_component/routes/index.tsx
@@ -7,7 +7,7 @@ import { SelfEvaluationPage } from '../src/assessment/pages/SelfAndPeerEvaluatio
 import { PeerEvaluationPage } from '../src/assessment/pages/SelfAndPeerEvaluationPage/PeerEvaluationPage'
 
 import { AssessmentDataShell } from '../src/assessment/pages/AssessmentDataShell'
-import { AssessmentOverviewPage } from '../src/assessment/pages/AssessmentOverviewPage/AssessmentOverviewPage'
+import { AssessmentParticipantsPage } from '../src/assessment/pages/AssessmentParticipantsPage/AssessmentParticipantsPage'
 import { AssessmentPage } from '../src/assessment/pages/AssessmentPage/AssessmentPage'
 import { AssessmentStatisticsPage } from '../src/assessment/pages/AssessmentStatisticsPage/AssessmentStatisticsPage'
 import { SettingsPage } from '../src/assessment/pages/SettingsPage/SettingsPage'
@@ -56,16 +56,16 @@ const routes: ExtendedRouteObject[] = [
     ],
   },
   {
-    path: '/overview',
+    path: '/participants',
     element: (
       <AssessmentDataShell>
-        <AssessmentOverviewPage />
+        <AssessmentParticipantsPage />
       </AssessmentDataShell>
     ),
     requiredPermissions: [Role.PROMPT_ADMIN, Role.COURSE_LECTURER, Role.COURSE_EDITOR],
   },
   {
-    path: '/overview/:courseParticipationID',
+    path: '/participants/:courseParticipationID',
     element: (
       <AssessmentDataShell>
         <AssessmentPage />

--- a/clients/assessment_component/sidebar/index.tsx
+++ b/clients/assessment_component/sidebar/index.tsx
@@ -14,8 +14,8 @@ const sidebarItems: SidebarMenuItemProps = {
   ],
   subitems: [
     {
-      title: 'Overview',
-      goToPath: '/overview',
+      title: 'Participants',
+      goToPath: '/participants',
       requiredPermissions: [Role.PROMPT_ADMIN, Role.COURSE_LECTURER, Role.COURSE_EDITOR],
     },
     {

--- a/clients/assessment_component/src/assessment/pages/AssessmentParticipantsPage/AssessmentParticipantsPage.tsx
+++ b/clients/assessment_component/src/assessment/pages/AssessmentParticipantsPage/AssessmentParticipantsPage.tsx
@@ -23,7 +23,7 @@ import { getLevelConfig } from '../utils/getLevelConfig'
 import { AssessmentDiagram } from '../components/diagrams/AssessmentDiagram'
 import { AssessmentScoreLevelDiagram } from '../components/diagrams/AssessmentScoreLevelDiagram'
 
-export const AssessmentOverviewPage = (): JSX.Element => {
+export const AssessmentParticipantsPage = (): JSX.Element => {
   const { phaseId } = useParams<{ phaseId: string }>()
   const navigate = useNavigate()
   const path = useLocation().pathname
@@ -179,7 +179,7 @@ export const AssessmentOverviewPage = (): JSX.Element => {
 
   return (
     <div id='table-view' className='relative flex flex-col'>
-      <ManagementPageHeader>Assessment Overview</ManagementPageHeader>
+      <ManagementPageHeader>Assessment Participants</ManagementPageHeader>
       <p className='text-sm text-muted-foreground mb-4'>
         Click on a participant to view/edit their assessment.
       </p>


### PR DESCRIPTION
# 📝 Assessment: Rename to Participants subpage

## 📌 Reason for the change / Link to issue

#674 

## 🧪 How to Test

1. Go to Assessment phase
2. Look at Participants page

## 🖼️ Screenshots (if UI changes are included)

| Before         | After         |
|-------------- | ------------- |
| <img width="1824" height="1167" alt="Bildschirmfoto 2025-07-11 um 18 28 17" src="https://github.com/user-attachments/assets/ca1f7ee3-2529-4800-bbc6-a7b20bcccccd" /> | <img width="1824" height="1167" alt="Bildschirmfoto 2025-07-11 um 18 28 43" src="https://github.com/user-attachments/assets/332cffd9-1a66-45b6-9c73-b504e3ce3fbf" /> |

## ✅ PR Checklist

- [x] Tested locally or on the dev environment
- [x] Code is clean, readable, and documented
- [x] Tests added or updated (if needed)
- [x] Screenshots attached for UI changes (if any)
- [x] Documentation updated (if relevant)