### PR TITLE
`Intro Course`: Rename to Participants subpage

### DIFF
--- a/clients/intro_course_developer_component/routes/index.tsx
+++ b/clients/intro_course_developer_component/routes/index.tsx
@@ -6,7 +6,7 @@ import { ExtendedRouteObject } from '@/interfaces/extendedRouteObject'
 import { Role } from '@tumaet/prompt-shared-state'
 import { SeatAssignmentPage } from '../src/introCourse/pages/SeatAssignment/SeatAssignmentPage'
 import { MailingPage } from '../src/introCourse/pages/Mailing/MailingPage'
-import { CoursePhaseParticipantsPage } from '../src/introCourse/pages/CoursePhaseParticipants/CoursePhaseParticipantsPage'
+import { IntroCourseParticipantsPage } from '../src/introCourse/pages/IntroCourseParticipantsPage/IntroCourseParticipantsPage'
 
 const routes: ExtendedRouteObject[] = [
   {
@@ -20,7 +20,7 @@ const routes: ExtendedRouteObject[] = [
   },
   {
     path: '/participants',
-    element: <CoursePhaseParticipantsPage />,
+    element: <IntroCourseParticipantsPage />,
     requiredPermissions: [Role.PROMPT_ADMIN, Role.COURSE_LECTURER],
   },
   {

--- a/clients/intro_course_developer_component/src/introCourse/pages/IntroCourseParticipantsPage/IntroCourseParticipantsPage.tsx
+++ b/clients/intro_course_developer_component/src/introCourse/pages/IntroCourseParticipantsPage/IntroCourseParticipantsPage.tsx
@@ -29,7 +29,7 @@ export const IntroCourseParticipantsPage = (): JSX.Element => {
         </div>
       ) : (
         <>
-          <ManagementPageHeader>Course Phase Participants</ManagementPageHeader>
+          <ManagementPageHeader>Intro Course Participants</ManagementPageHeader>
           <CoursePhaseParticipationsTablePage
             participants={coursePhaseParticipations?.participations ?? []}
             prevDataKeys={[]}

--- a/clients/intro_course_developer_component/src/introCourse/pages/IntroCourseParticipantsPage/IntroCourseParticipantsPage.tsx
+++ b/clients/intro_course_developer_component/src/introCourse/pages/IntroCourseParticipantsPage/IntroCourseParticipantsPage.tsx
@@ -6,7 +6,7 @@ import { CoursePhaseParticipationsWithResolution } from '@tumaet/prompt-shared-s
 import { Loader2 } from 'lucide-react'
 import { useParams } from 'react-router-dom'
 
-export const CoursePhaseParticipantsPage = (): JSX.Element => {
+export const IntroCourseParticipantsPage = (): JSX.Element => {
   const { phaseId } = useParams<{ phaseId: string }>()
 
   const {


### PR DESCRIPTION
# 📝 Intro Course: Rename to Participants subpage

## 📌 Reason for the change / Link to issue

#675 

## 🧪 How to Test

1. Go to Intro Course phase
2. Look at Participants page

## 🖼️ Screenshots (if UI changes are included)

| Before         | After         |
|-------------- | ------------- |
| <img width="1824" height="1167" alt="Bildschirmfoto 2025-07-11 um 19 06 23" src="https://github.com/user-attachments/assets/474d60bf-754b-4bb7-95e8-7946d9a4b3ec" /> |  <img width="1824" height="1167" alt="Bildschirmfoto 2025-07-11 um 19 08 43" src="https://github.com/user-attachments/assets/8116bc9c-3214-48e3-a28d-d563f9aca494" /> |

## ✅ PR Checklist

- [x] Tested locally or on the dev environment
- [x] Code is clean, readable, and documented
- [x] Tests added or updated (if needed)
- [x] Screenshots attached for UI changes (if any)
- [x] Documentation updated (if relevant)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the participants page header text to "Intro Course Participants" for improved clarity.

* **Chores**
  * Renamed the participants page component for consistency across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->