### PR TITLE
`Self Team Allocation`: Rename to Participants subpage

### DIFF
--- a/clients/self_team_allocation_component/routes/index.tsx
+++ b/clients/self_team_allocation_component/routes/index.tsx
@@ -1,7 +1,7 @@
 import { Role } from '@tumaet/prompt-shared-state'
 import { ExtendedRouteObject } from '@/interfaces/extendedRouteObject'
 import { SelfTeamAllocationPage } from '../src/self_team_allocation/pages/TeamAllocation/SelfTeamAllocationPage'
-import { AllocationParticipants } from '../src/self_team_allocation/pages/AllocationParticipants/AllocationParticipantsPage'
+import { SelfTeamAllocationParticipantsPage } from '../src/self_team_allocation/pages/SelfTeamAllocationParticipantsPage/SelfTeamAllocationParticipantsPage'
 import { SettingsPage } from '../src/self_team_allocation/pages/Settings/SettingsPage'
 
 const routes: ExtendedRouteObject[] = [
@@ -17,7 +17,7 @@ const routes: ExtendedRouteObject[] = [
   },
   {
     path: '/participants',
-    element: <AllocationParticipants />,
+    element: <SelfTeamAllocationParticipantsPage />,
     requiredPermissions: [Role.PROMPT_ADMIN, Role.COURSE_LECTURER],
   },
   {

--- a/clients/self_team_allocation_component/sidebar/index.tsx
+++ b/clients/self_team_allocation_component/sidebar/index.tsx
@@ -14,7 +14,7 @@ const sidebarItems: SidebarMenuItemProps = {
   ],
   subitems: [
     {
-      title: 'Survey Participants',
+      title: 'Participants',
       goToPath: '/participants',
       requiredPermissions: [Role.PROMPT_ADMIN, Role.COURSE_LECTURER],
     },

--- a/clients/self_team_allocation_component/src/self_team_allocation/pages/SelfTeamAllocationParticipantsPage/SelfTeamAllocationParticipantsPage.tsx
+++ b/clients/self_team_allocation_component/src/self_team_allocation/pages/SelfTeamAllocationParticipantsPage/SelfTeamAllocationParticipantsPage.tsx
@@ -10,7 +10,7 @@ import { getAllTeams } from '../../network/queries/getAllTeams'
 import { useMemo } from 'react'
 import { ExtraParticipationTableColumn } from '@/components/pages/CoursePhaseParticpationsTable/interfaces/ExtraParticipationTableColumn'
 
-export const AllocationParticipants = (): JSX.Element => {
+export const SelfTeamAllocationParticipantsPage = (): JSX.Element => {
   const { phaseId } = useParams<{ phaseId: string }>()
 
   const {
@@ -89,7 +89,7 @@ export const AllocationParticipants = (): JSX.Element => {
 
   return (
     <div id='table-view' className='relative flex flex-col'>
-      <ManagementPageHeader>Team Allocation Participants</ManagementPageHeader>
+      <ManagementPageHeader>Self Team Allocation Participants</ManagementPageHeader>
       <p className='text-sm text-muted-foreground mb-4'>
         This table shows all participants and their allocated teams.
       </p>


### PR DESCRIPTION
# 📝 Self Team Allocation: Rename to Participants subpage

## 📌 Reason for the change / Link to issue

#676 

## 🧪 How to Test

1. Go to Self Team Allocation phase
2. Look at Participants page

## 🖼️ Screenshots (if UI changes are included)

| Before         | After         |
|-------------- | ------------- |
| <img width="1824" height="1167" alt="Bildschirmfoto 2025-07-11 um 19 20 43" src="https://github.com/user-attachments/assets/a2c4195e-f1fa-49d4-b372-a34026c18751" /> | <img width="1824" height="1167" alt="Bildschirmfoto 2025-07-11 um 19 21 01" src="https://github.com/user-attachments/assets/a202ecb5-4d28-4854-890e-fda5cf7ca40f" /> |

## ✅ PR Checklist

- [x] Tested locally or on the dev environment
- [x] Code is clean, readable, and documented
- [x] Tests added or updated (if needed)
- [x] Screenshots attached for UI changes (if any)
- [x] Documentation updated (if relevant)