### PR TITLE
Team Allocation: Rename to Participants subpage

### DIFF
--- a/clients/team_allocation_component/routes/index.tsx
+++ b/clients/team_allocation_component/routes/index.tsx
@@ -4,7 +4,7 @@ import { ExtendedRouteObject } from '@/interfaces/extendedRouteObject'
 import { StudentSurveyPage } from '../src/team_allocation/pages/StudentSurvey/StudentSurveyPage'
 import { TeamAllocationPage } from '../src/team_allocation/pages/TeamAllocation/TeamAllocationPage'
 import { TeaseConfigPage } from '../src/team_allocation/pages/TeaseConfig/TeaseConfigPage'
-import { ParticipantsPage } from '../src/team_allocation/pages/Participants/ParticipantsPage'
+import { TeamAllocationParticipantsPage } from '../src/team_allocation/pages/TeamAllocationParticipantsPage/TeamAllocationParticipantsPage'
 
 const routes: ExtendedRouteObject[] = [
   {
@@ -34,7 +34,7 @@ const routes: ExtendedRouteObject[] = [
   },
   {
     path: '/participants',
-    element: <ParticipantsPage />,
+    element: <TeamAllocationParticipantsPage />,
     requiredPermissions: [Role.PROMPT_ADMIN, Role.COURSE_LECTURER],
   },
 ]

--- a/clients/team_allocation_component/src/team_allocation/pages/TeamAllocationParticipantsPage/TeamAllocationParticipantsPage.tsx
+++ b/clients/team_allocation_component/src/team_allocation/pages/TeamAllocationParticipantsPage/TeamAllocationParticipantsPage.tsx
@@ -14,7 +14,7 @@ import { Allocation } from '../../interfaces/allocation'
 import { useEffect } from 'react'
 import { addStudentNamesToTeams } from '../../network/mutations/addStudentNamesToTeams'
 
-export const ParticipantsPage = (): JSX.Element => {
+export const TeamAllocationParticipantsPage = (): JSX.Element => {
   const { phaseId } = useParams<{ phaseId: string }>()
 
   const {


### PR DESCRIPTION
# 📝 Team Allocation: Rename to Participants subpage

## 📌 Reason for the change / Link to issue

#677 

## 🧪 How to Test

1. Go to Team Allocation phase
2. Look at Participants page

## 🖼️ Screenshots (if UI changes are included)

| Before         | After         |
|-------------- | ------------- |
|  |  |

## ✅ PR Checklist

- [x] Tested locally or on the dev environment
- [x] Code is clean, readable, and documented
- [x] Tests added or updated (if needed)
- [x] Screenshots attached for UI changes (if any)
- [x] Documentation updated (if relevant)