### PR TITLE
`Assessment`: Update Assessment Diagram to show assessment progress

### DIFF
--- a/clients/assessment_component/src/assessment/pages/AssessmentParticipantsPage/AssessmentParticipantsPage.tsx
+++ b/clients/assessment_component/src/assessment/pages/AssessmentParticipantsPage/AssessmentParticipantsPage.tsx
@@ -373,7 +373,11 @@ export const AssessmentParticipantsPage = (): JSX.Element => {
         Click on a participant to view/edit their assessment.
       </p>
       <div className='grid gap-6 grid-cols-1 lg:grid-cols-2 mb-6'>
-        <AssessmentDiagram participations={participations} scoreLevels={scoreLevels} />
+        <AssessmentDiagram
+          participations={participations}
+          scoreLevels={scoreLevels}
+          completions={assessmentCompletions}
+        />
         <AssessmentScoreLevelDiagram participations={participations} scoreLevels={scoreLevels} />
       </div>
       <div className='w-full'>

--- a/clients/assessment_component/src/assessment/pages/AssessmentStatisticsPage/AssessmentStatisticsPage.tsx
+++ b/clients/assessment_component/src/assessment/pages/AssessmentStatisticsPage/AssessmentStatisticsPage.tsx
@@ -78,7 +78,11 @@ export const AssessmentStatisticsPage = (): JSX.Element => {
       <ManagementPageHeader>Assessment Statistics</ManagementPageHeader>
 
       <div className='grid gap-6 grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4 mb-6'>
-        <AssessmentDiagram participations={participations} scoreLevels={scoreLevels} />
+        <AssessmentDiagram
+          participations={participations}
+          scoreLevels={scoreLevels}
+          completions={assessmentCompletions}
+        />
         <AssessmentScoreLevelDiagram participations={participations} scoreLevels={scoreLevels} />
         <GenderDiagram participationsWithAssessment={participationsWithAssessments} />
         <CategoryDiagram categories={categories} assessments={assessments} />

--- a/clients/assessment_component/src/assessment/pages/components/diagrams/AssessmentDiagram.tsx
+++ b/clients/assessment_component/src/assessment/pages/components/diagrams/AssessmentDiagram.tsx
@@ -24,7 +24,7 @@ const chartConfig = {
   },
   inProgress: {
     label: 'In Progress',
-    color: '#FBD38D', // Light orange
+    color: '#63B3ED', // Light blue
   },
   completed: {
     label: 'Completed',

--- a/clients/assessment_component/src/assessment/pages/components/diagrams/AssessmentDiagram.tsx
+++ b/clients/assessment_component/src/assessment/pages/components/diagrams/AssessmentDiagram.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react'
 import { Label, Pie, PieChart } from 'recharts'
 
-import { PassStatus } from '@tumaet/prompt-shared-state'
 import {
   Card,
   CardContent,
@@ -16,60 +15,66 @@ import {
 
 import { AssessmentParticipationWithStudent } from '../../../interfaces/assessmentParticipationWithStudent'
 import { ScoreLevelWithParticipation } from '../../../interfaces/scoreLevelWithParticipation'
+import { CompetencyScoreCompletion } from '../../../interfaces/competencyScoreCompletion'
 
 const chartConfig = {
-  assessments: {
-    label: 'Assessments',
-  },
   notAssessed: {
     label: 'Not Assessed',
     color: 'hsl(var(--muted))',
   },
+  inProgress: {
+    label: 'In Progress',
+    color: '#FBD38D', // Light orange
+  },
   completed: {
-    label: 'Completed waiting for acceptance',
-    color: '#63B3ED', // Light blue
-  },
-  accepted: {
-    label: 'Accepted',
+    label: 'Completed',
     color: 'hsl(var(--success))',
-  },
-  rejected: {
-    label: 'Rejected',
-    color: 'hsl(var(--destructive))',
   },
 } satisfies ChartConfig
 
 interface AssessmentDiagramProps {
   participations: AssessmentParticipationWithStudent[]
   scoreLevels: ScoreLevelWithParticipation[]
+  completions: CompetencyScoreCompletion[]
+  isEvaluation?: boolean
 }
 
 export const AssessmentDiagram = ({
   participations,
   scoreLevels,
+  completions,
+  isEvaluation = false,
 }: AssessmentDiagramProps): JSX.Element => {
   const { chartData, totalAssessments } = React.useMemo(() => {
-    const accepted = participations.filter((app) => app.passStatus === PassStatus.PASSED).length
-    const rejected = participations.filter((app) => app.passStatus === PassStatus.FAILED).length
-    const notAssessed = participations.length - scoreLevels.length
-    const completed = Math.max(0, participations.length - notAssessed - accepted - rejected)
+    const completed = participations.filter((p) =>
+      completions?.find((c) => c.courseParticipationID === p.courseParticipationID && c.completed),
+    ).length
+
+    const inProgress = participations.filter(
+      (p) =>
+        scoreLevels.some((sl) => sl.courseParticipationID === p.courseParticipationID) &&
+        !completions?.find((c) => c.courseParticipationID === p.courseParticipationID)?.completed,
+    ).length
+
+    const notAssessed = participations.length - completed - inProgress
 
     return {
       chartData: [
         { status: 'notAssessed', applications: notAssessed, fill: chartConfig.notAssessed.color },
-        { status: 'accepted', applications: accepted, fill: chartConfig.accepted.color },
-        { status: 'rejected', applications: rejected, fill: chartConfig.rejected.color },
+        { status: 'inProgress', applications: inProgress, fill: chartConfig.inProgress.color },
         { status: 'completed', applications: completed, fill: chartConfig.completed.color },
       ],
       totalAssessments: participations.length,
     }
-  }, [participations, scoreLevels])
+  }, [participations, completions, scoreLevels])
 
   return (
     <Card className='flex flex-col'>
       <CardHeader className='items-center pb-0'>
-        <CardTitle>Assessments</CardTitle>
-        <CardDescription>All assessments and their status</CardDescription>
+        <CardTitle>{isEvaluation ? 'Evaluation' : 'Assessments'}</CardTitle>
+        <CardDescription>
+          All {isEvaluation ? 'evaluations' : 'assessments'} and their status
+        </CardDescription>
       </CardHeader>
       <CardContent className='flex-1 pb-0'>
         <ChartContainer config={chartConfig} className='mx-auto aspect-square max-h-[250px]'>


### PR DESCRIPTION
# 📝 Update Assessment Diagram to show assessment progress

## ✨ What is the change?

<!-- Briefly describe what has been changed or added in this PR. -->

Instead of showing a mixture between passStatus and assessmentCompletion status, the assessmentDiagram now shows only the Assessment status. 

## 📌 Reason for the change / Link to issue

<!-- Explain why this change was made. Optionally include a link to the relevant issue or ticket. -->

closes #627 

## 🧪 How to Test

<!-- List the steps someone should follow to test this PR. -->

1. Navigate to the assessment participants page
2. Look at the new diagram style

## ✅ PR Checklist

- [x] Tested locally or on the dev environment
- [x] Code is clean, readable, and documented
- [x] Tests added or updated (if needed)
- [x] Screenshots attached for UI changes (if any)
- [x] Documentation updated (if relevant)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Assessment and evaluation diagrams now display updated status categories based on completion data, including a new "in progress" status.
  * Diagrams can now toggle between "Assessments" and "Evaluations" views with corresponding titles and descriptions.

* **Refactor**
  * Status calculations in diagrams have been updated to use completion information instead of pass/fail status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->