### PR TITLE
`Assessment`: Add debounce to assessment form

### DIFF
--- a/clients/assessment_component/src/assessment/pages/AssessmentPage/components/AssessmentCompletion/components/ActionItemPanel.tsx
+++ b/clients/assessment_component/src/assessment/pages/AssessmentPage/components/AssessmentCompletion/components/ActionItemPanel.tsx
@@ -56,10 +56,10 @@ export function ActionItemPanel() {
   const { user } = useAuthStore()
   const userName = user ? `${user.firstName} ${user.lastName}` : 'Unknown User'
 
-  const addActionItem = async () => {
+  const handleAddActionItem = async () => {
     if (completed) return
 
-    return await createActionItem({
+    await createActionItem({
       coursePhaseID: phaseId ?? '',
       courseParticipationID: courseParticipationID ?? '',
       action: '',
@@ -88,7 +88,14 @@ export function ActionItemPanel() {
         author: userName,
       }
 
-      updateActionItem(updateRequest)
+      updateActionItem(updateRequest, {
+        onSuccess: () => {
+          setSavingItemId(undefined)
+        },
+        onError: () => {
+          setSavingItemId(undefined)
+        },
+      })
     }
   }
 
@@ -156,7 +163,7 @@ export function ActionItemPanel() {
           <Button
             variant='outline'
             className='w-full border-dashed flex items-center justify-center p-6 hover:bg-muted/50 transition-colors'
-            onClick={addActionItem}
+            onClick={handleAddActionItem}
             disabled={isPending || completed}
             title={
               completed

--- a/clients/assessment_component/src/assessment/pages/AssessmentPage/components/AssessmentForm/AssessmentForm.tsx
+++ b/clients/assessment_component/src/assessment/pages/AssessmentPage/components/AssessmentForm/AssessmentForm.tsx
@@ -99,7 +99,7 @@ export const AssessmentForm = ({
           timeoutRef.current = setTimeout(async () => {
             // Check if component is still mounted before proceeding
             if (!mountedRef.current) return
-            
+
             const isValid = await form.trigger(name)
             if (isValid) {
               const data = form.getValues()

--- a/clients/assessment_component/src/assessment/pages/AssessmentPage/components/AssessmentForm/AssessmentForm.tsx
+++ b/clients/assessment_component/src/assessment/pages/AssessmentPage/components/AssessmentForm/AssessmentForm.tsx
@@ -87,19 +87,30 @@ export const AssessmentForm = ({
 
     const subscription = form.watch(async (_, { name }) => {
       if (name) {
-        // Clear any existing timeout
-        if (timeoutRef.current) {
-          clearTimeout(timeoutRef.current)
-        }
+        // For text fields (comment, examples), use debounce
+        if (name === 'comment' || name === 'examples') {
+          // Clear any existing timeout
+          if (timeoutRef.current) {
+            clearTimeout(timeoutRef.current)
+          }
 
-        // Set a new timeout to debounce the API call
-        timeoutRef.current = setTimeout(async () => {
+          // Set a new timeout to debounce the API call
+          timeoutRef.current = setTimeout(async () => {
+            const isValid = await form.trigger('comment')
+            if (isValid) {
+              const data = form.getValues()
+              createOrUpdateAssessment(data)
+            }
+          }, 500) // 500ms debounce delay
+        }
+        // For other fields (like scoreLevel), save immediately
+        else {
           const isValid = await form.trigger('comment')
           if (isValid) {
             const data = form.getValues()
             createOrUpdateAssessment(data)
           }
-        }, 500) // 500ms debounce delay
+        }
       }
     })
 

--- a/clients/assessment_component/src/assessment/pages/SelfAndPeerEvaluationPage/components/EvaluationCompletionPage/components/FeedbackItemPanel.tsx
+++ b/clients/assessment_component/src/assessment/pages/SelfAndPeerEvaluationPage/components/EvaluationCompletionPage/components/FeedbackItemPanel.tsx
@@ -74,10 +74,10 @@ export function FeedbackItemPanel({
     }
   }, [feedbackItems, itemValues])
 
-  const addFeedbackItem = async () => {
+  const handleAddFeedbackItem = async () => {
     if (completed) return
 
-    return await createFeedbackItem({
+    await createFeedbackItem({
       feedbackType,
       courseParticipationID,
       authorCourseParticipationID,
@@ -106,7 +106,14 @@ export function FeedbackItemPanel({
         authorCourseParticipationID: item.authorCourseParticipationID,
       }
 
-      updateFeedbackItem(updateRequest)
+      updateFeedbackItem(updateRequest, {
+        onSuccess: () => {
+          setSavingItemId(undefined)
+        },
+        onError: () => {
+          setSavingItemId(undefined)
+        },
+      })
     }
   }
 
@@ -196,7 +203,7 @@ export function FeedbackItemPanel({
           <Button
             variant='outline'
             className='w-full border-dashed flex items-center justify-center p-6 hover:bg-muted/50 transition-colors'
-            onClick={addFeedbackItem}
+            onClick={handleAddFeedbackItem}
             disabled={isPending || completed}
             title={
               completed ? 'Evaluation completed - cannot add new feedback items' : addButtonText

--- a/clients/assessment_component/src/assessment/pages/components/ItemRow.tsx
+++ b/clients/assessment_component/src/assessment/pages/components/ItemRow.tsx
@@ -8,6 +8,7 @@ import type { FeedbackItem } from '../../interfaces/feedbackItem'
 interface BaseItemRowProps {
   value: string
   onTextChange: (itemId: string, value: string) => void
+  onTextBlur?: (itemId: string) => void
   onDelete: (itemId: string) => void
   isSaving: boolean
   isPending: boolean
@@ -32,6 +33,7 @@ export function ItemRow({
   item,
   value,
   onTextChange,
+  onTextBlur,
   onDelete,
   isPending,
   isDisabled = false,
@@ -74,8 +76,12 @@ export function ItemRow({
               return cleanup
             }
           }}
+          onBlur={() => {
+            if (!isDisabled && onTextBlur) {
+              onTextBlur(item.id)
+            }
+          }}
           placeholder={getDefaultPlaceholder()}
-          disabled={isDisabled}
           readOnly={isDisabled}
         />
       </div>


### PR DESCRIPTION
# 📝 Add debounce to assessment form

## ✨ What is the change?

<!-- Briefly describe what has been changed or added in this PR. -->

Add a debounce for the assessment form. 

## 📌 Reason for the change / Link to issue

<!-- Explain why this change was made. Optionally include a link to the relevant issue or ticket. -->

closes #774

## 🧪 How to Test

<!-- List the steps someone should follow to test this PR. -->

1. Type in the assessment form
2. Instead of sending a request while you type, it only sends one when you stop typing for 500ms


## ✅ PR Checklist

- [x] Tested locally or on the dev environment
- [x] Code is clean, readable, and documented


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Text fields in the assessment form (such as "comment" and "examples") now save changes only after the field loses focus, reducing interruptions during typing.
  * Action items and feedback items now update only when input fields lose focus, improving responsiveness and reducing unnecessary save calls.
* **Bug Fixes**
  * Improved cleanup to prevent unnecessary save operations and potential memory leaks when leaving the form.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->