### PR TITLE
`Core`: Show a preview of recipient count before manually sending out email

### DIFF
--- a/clients/shared_library/components/pages/Mailing/components/ConfirmSendEmailDialog.tsx
+++ b/clients/shared_library/components/pages/Mailing/components/ConfirmSendEmailDialog.tsx
@@ -1,8 +1,10 @@
 import { Send, Loader2, AlertCircle, CheckCircle, X } from 'lucide-react'
 import { useMutation } from '@tanstack/react-query'
 import { useParams } from 'react-router-dom'
+import { useState, useEffect } from 'react'
 import { SendStatusMail, PassStatus } from '@tumaet/prompt-shared-state'
 import { sendStatusMail } from '@/network/mutations/sendStatusMail'
+import { getCoursePhaseParticipationStatusCounts } from '@/network/queries/getCoursePhaseParticipationStatusCounts'
 import {
   Dialog,
   DialogContent,
@@ -29,6 +31,8 @@ export const ConfirmSendEmailDialog = ({
 }: ConfirmSendEmailDialogProps): JSX.Element => {
   const { phaseId } = useParams<{ phaseId: string }>()
 
+  const [mailRecipients, setMailRecipients] = useState({})
+
   const {
     mutate: sendEmails,
     isPending,
@@ -51,6 +55,14 @@ export const ConfirmSendEmailDialog = ({
     onClose()
   }
 
+  useEffect(() => {
+    const fetchMailRecipientsCount = async () => {
+      const data = await getCoursePhaseParticipationStatusCounts(phaseId ?? '')
+      setMailRecipients(data)
+    }
+    fetchMailRecipientsCount()
+  }, [phaseId])
+
   return (
     <Dialog open={isOpen} onOpenChange={handleClose}>
       <DialogContent>
@@ -69,6 +81,14 @@ export const ConfirmSendEmailDialog = ({
               !isError &&
               !data &&
               `Are you sure you want to send an Email to ALL students that ${emailType === PassStatus.PASSED ? 'have been accepted' : 'have been rejected'}?`}
+          </DialogDescription>
+          <DialogDescription>
+            {!isPending && !isError && !data && (
+              <>
+                This will send out an email to{' '}
+                <span className='font-bold'>{mailRecipients[emailType] ?? 0} recipients</span>
+              </>
+            )}
           </DialogDescription>
         </DialogHeader>
 

--- a/clients/shared_library/network/queries/getCoursePhaseParticipationStatusCounts.ts
+++ b/clients/shared_library/network/queries/getCoursePhaseParticipationStatusCounts.ts
@@ -1,0 +1,28 @@
+import { axiosInstance } from '@/network/configService'
+
+export interface CoursePhaseParticipationStatusCounts {
+    [key: string]: number
+}
+
+type CoursePhaseParticipationStatusCountsResponse = {
+    pass_status: { pass_status: string, valid: boolean },
+    count: number
+}[]
+
+const transformStatusCounts = (data: CoursePhaseParticipationStatusCountsResponse): CoursePhaseParticipationStatusCounts => {
+  return data.reduce((acc, curr) => {
+    const statusKey = curr.pass_status.pass_status
+    acc[statusKey] = curr.count
+    return acc
+  }, {} as CoursePhaseParticipationStatusCounts)
+}
+
+export const getCoursePhaseParticipationStatusCounts = async (phaseId: string): Promise<CoursePhaseParticipationStatusCounts> => {
+  try {
+    let data: CoursePhaseParticipationStatusCountsResponse = (await axiosInstance.get(`/api/course_phases/${phaseId}/participation_status_counts`)).data
+    return transformStatusCounts(data)
+  } catch (err) {
+    console.error(err)
+    throw err
+  }
+}

--- a/servers/core/coursePhase/router.go
+++ b/servers/core/coursePhase/router.go
@@ -22,6 +22,7 @@ func setupCoursePhaseRouter(router *gin.RouterGroup, authMiddleware func() gin.H
 	coursePhase := router.Group("/course_phases", authMiddleware())
 	coursePhase.GET("/:uuid", permissionIDMiddleware(permissionValidation.PromptAdmin, permissionValidation.CourseLecturer, permissionValidation.CourseEditor, permissionValidation.CourseStudent), getCoursePhaseByID)
 	coursePhase.GET("/:uuid/course_phase_data", permissionIDMiddleware(permissionValidation.PromptAdmin, permissionValidation.CourseLecturer, permissionValidation.CourseEditor, permissionValidation.CourseStudent), getPrevPhaseDataByCoursePhaseID)
+	coursePhase.GET("/:uuid/participation_status_counts", permissionIDMiddleware(permissionValidation.PromptAdmin, permissionValidation.CourseLecturer, permissionValidation.CourseEditor), getCoursePhaseParticipationStatusCounts)
 
 	// getting the course ID here to do correct rights management
 	coursePhase.POST("/course/:courseID", permissionCourseIDMiddleware(permissionValidation.PromptAdmin, permissionValidation.CourseLecturer), createCoursePhase)
@@ -217,4 +218,20 @@ func handleError(c *gin.Context, statusCode int, err error) {
 	c.JSON(statusCode, utils.ErrorResponse{
 		Error: err.Error(),
 	})
+}
+
+func getCoursePhaseParticipationStatusCounts(c *gin.Context) {
+	id, err := uuid.Parse(c.Param("uuid"))
+	if err != nil {
+		handleError(c, http.StatusBadRequest, err)
+		return
+	}
+
+	counts, err := CoursePhaseServiceSingleton.queries.GetCoursePhaseParticipationStatusCounts(c, id)
+	if err != nil {
+		handleError(c, http.StatusInternalServerError, err)
+		return
+	}
+
+	c.IndentedJSON(http.StatusOK, counts)
 }

--- a/servers/core/db/query/course_phase_participation.sql
+++ b/servers/core/db/query/course_phase_participation.sql
@@ -75,6 +75,11 @@ WHERE
   AND pass_status != sqlc.arg(pass_status)::pass_status
 RETURNING course_participation_id;
 
+-- name: GetCoursePhaseParticipationStatusCounts :many
+SELECT pass_status, COUNT(*) AS count
+FROM course_phase_participation
+WHERE course_phase_id = $1
+GROUP BY pass_status;
 
 -- name: GetAllCoursePhaseParticipationsForCoursePhaseIncludingPrevious :many
 WITH 

--- a/servers/core/db/sqlc/course_phase_participation.sql.go
+++ b/servers/core/db/sqlc/course_phase_participation.sql.go
@@ -655,6 +655,38 @@ func (q *Queries) GetCoursePhaseParticipationByUniversityLoginAndCoursePhase(ctx
 	return i, err
 }
 
+const getCoursePhaseParticipationStatusCounts = `-- name: GetCoursePhaseParticipationStatusCounts :many
+SELECT pass_status, COUNT(*) AS count
+FROM course_phase_participation
+WHERE course_phase_id = $1
+GROUP BY pass_status
+`
+
+type GetCoursePhaseParticipationStatusCountsRow struct {
+	PassStatus NullPassStatus `json:"pass_status"`
+	Count      int64          `json:"count"`
+}
+
+func (q *Queries) GetCoursePhaseParticipationStatusCounts(ctx context.Context, coursePhaseID uuid.UUID) ([]GetCoursePhaseParticipationStatusCountsRow, error) {
+	rows, err := q.db.Query(ctx, getCoursePhaseParticipationStatusCounts, coursePhaseID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []GetCoursePhaseParticipationStatusCountsRow
+	for rows.Next() {
+		var i GetCoursePhaseParticipationStatusCountsRow
+		if err := rows.Scan(&i.PassStatus, &i.Count); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const getStudentsOfCoursePhase = `-- name: GetStudentsOfCoursePhase :many
 WITH 
   -----------------------------------------------------------------------


### PR DESCRIPTION
## ✨ What is the change?

When manually sending out acceptance or rejection mails, the user will now see a preview of how many people will receive that email.

## 📌 Reason for the change / Link to issue

fixes #202 

## 🧪 How to Test

1. clone into this branch, start the database, server and client
2. create a course that has an application phase
3. add some members (and accept or reject some of them)
4. Go to Course Phases > Your application phase > Mailing  and click on "Send Acceptance Mails" or "Send Rejection Mails" to see the preview

## 🖼️ Screenshots (if UI changes are included)
![comparison](https://github.com/user-attachments/assets/a0a6c3d3-e4cf-49a2-8968-55e12d8978cc)

## What I changed / added
- The ConfirmSendEmailDialog component, which handles manually sending out emails, will now, upon triggering fetch the recipients count from a new REST route: /api/coure_phases/:uuid/participation_status_counts
- There is a new corresponding endpoint in the go main server that handles the request, sums up the amounts and returns them

_Reasoning:_
Backend
- While some coursephases have shared state that could be used to leverage existing data and reduce the amount of requests, the ManualMailSending component is being used by multiple course phases.
- therefore the counter that shows the amount of recipients must work for all course phases and can not make use of a zustand (like the one from the Application) part or other state for a specific coursephase.
- Since every course phase has the table course_phase_participation, this is the best place to get the info for every course phase, that's why adding a query here makes sense
Frontend
- I put the acutal trigger for the request inside of the ConfirmSendEmailDialog, because (1): if the user does not  not trigger the dialog, no request will be performed, keeping the system minimal (2): inside of this dialog, the current coursephase id is already being used for the other requests (like the ones requesting the mail send) anyways, allowing me to reuse it

## ✅ PR Checklist

- [x] Tested locally or on the dev environment
- [x] Code is clean, readable, and documented
- [ ] Tests added or updated (if needed)
- [x] Screenshots attached for UI changes (if any)
- No Documentation added, deemed irrelevant
