### PR TITLE
`Core`: Update breadcrumb logic

### DIFF
--- a/clients/core/src/managementConsole/layout/Breadcrumbs/Breadcrumbs.tsx
+++ b/clients/core/src/managementConsole/layout/Breadcrumbs/Breadcrumbs.tsx
@@ -59,10 +59,16 @@ export const Breadcrumbs: React.FC = () => {
             }
             pathSegments.slice(4).forEach((segment, index) => {
               // TODO: this might require a more sophisticated process in the future!
-              // we assume that longer items are ids
+              // we assume that longer items are courseParticipationIDs
               if (segment.length < 20) {
                 breadcrumbs.push({
                   title: capitalizeFirstLetter(segment),
+                  path: `/management/course/${courseId}/${phaseId}/${pathSegments.slice(4, index + 5).join('/')}`,
+                })
+              } else {
+                // This is likely a courseParticipationID (long UUID)
+                breadcrumbs.push({
+                  title: 'Participant',
                   path: `/management/course/${courseId}/${phaseId}/${pathSegments.slice(4, index + 5).join('/')}`,
                 })
               }


### PR DESCRIPTION
# 📝 Update breadcrumb logic

## ✨ What is the change?

<!-- Briefly describe what has been changed or added in this PR. -->

For subpages of the participant page, assume that IDs are courseParticipationIDs and show a participant label for them. 

## 📌 Reason for the change / Link to issue

<!-- Explain why this change was made. Optionally include a link to the relevant issue or ticket. -->

closes #807 

## 🧪 How to Test

<!-- List the steps someone should follow to test this PR. -->

1. Navigate to the assessment participants page
2. Click on a row to get to the student assessment
3. Navigate back to the assessment participants page using the breadcrumbs

## 🖼️ Screenshots (if UI changes are included)

<!-- Include before/after screenshots if this PR involves any visual changes. -->

| Before         | After         |
| -------------- | ------------- |
| <img width="581" height="61" alt="Bildschirmfoto 2025-08-20 um 15 29 17" src="https://github.com/user-attachments/assets/6b79cdc6-a829-4195-b1e0-2f45de2856d4" /> | <img width="529" height="52" alt="Bildschirmfoto 2025-08-20 um 15 28 57" src="https://github.com/user-attachments/assets/a449c423-5be9-4a61-983e-739984cae873" /> |

## ✅ PR Checklist

- [x] Tested locally or on the dev environment
- [x] Code is clean, readable, and documented
no Tests added or updated (if needed)
- [x] Screenshots attached for UI changes (if any)
- [x] Documentation updated (if relevant)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Breadcrumbs now include a “Participant” item when navigating to participant-specific pages, improving clarity and context.
  * Long URL segments representing participant identifiers are now translated into a user-friendly breadcrumb label with a correct link path.
  * Enhances navigation by ensuring deep links display a complete breadcrumb trail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->