### PR TITLE
`Team Allocation`: Adapt team Allocation to support 5-level scoreLevel input

### DIFF
--- a/servers/team_allocation/tease/teaseDTO/student.go
+++ b/servers/team_allocation/tease/teaseDTO/student.go
@@ -154,16 +154,6 @@ func parseDeviceData(rawDevices interface{}) []string {
 // Maps 5-level score levels (VeryBad-VeryGood) to 4-level skill proficiency (Novice-Expert)
 func getTeaseScoreLevel(skillLevel string) string {
 	switch skillLevel {
-	// Legacy 4-level mapping (for backward compatibility)
-	case "novice":
-		return "Novice"
-	case "intermediate":
-		return "Intermediate"
-	case "advanced":
-		return "Advanced"
-	case "expert":
-		return "Expert"
-	// New 5-level to 4-level mapping
 	case "veryBad", "bad":
 		return "Novice"
 	case "ok":


### PR DESCRIPTION
# 📝 Adapt team Allocation to support 5-level scoreLevel input

## ✨ What is the change?

<!-- Briefly describe what has been changed or added in this PR. -->

Adapt the existing 4 level skill level input (`Novice`-`Expert`) the Team Allocation to the 5 level scoreLevel system (`VeryBad`-`VeryGood`) used in the assessment system. 

## 📌 Reason for the change / Link to issue

<!-- Explain why this change was made. Optionally include a link to the relevant issue or ticket. -->

closes #831 

## 🧪 How to Test

<!-- List the steps someone should follow to test this PR. -->

As Tease is usually not deployed on your local machine, test this feature on the dev server. 

## ✅ PR Checklist

- [x] Tested locally or on the dev environment
- [x] Code is clean, readable, and documented


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for five-level score inputs (Very Bad, Bad, OK, Good, Very Good), automatically translated into four proficiency levels (Novice, Intermediate, Advanced, Expert).
  * Proficiency labels across the UI and reports now reflect the updated mapping.
  * Unrecognized or missing scores continue to display as “Unknown.”

* **Refactor**
  * Updated internal score-to-proficiency mapping logic to align with the new five-level input scale.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->