### PR TITLE
`General`: Rename deploy-dev-container job to deploy-prod in workflow configuration

### DIFF
--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -27,7 +27,7 @@ jobs:
     secrets: inherit
     with:
       release_tag: "${{ github.event.release.tag_name }},latest"
-  deploy-dev-container:
+  deploy-prod:
     needs: [build-clients, build-servers]
     uses: ./.github/workflows/deploy-docker.yml
     secrets: inherit


### PR DESCRIPTION
Renamed job name from deploy-dev-container to deploy prod in prod.yml

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Deployment workflow infrastructure has been updated with renamed identifiers for production deployment processes. All associated configurations, parameters, environment settings, secrets, and critical dependencies maintain their original specifications and remain fully intact. Workflow triggers, execution steps, operational behavior, and deployment functionality remain completely unchanged. This update addresses infrastructure naming refinements exclusively.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->