### PR TITLE
`Assessment`: Adjust CompetencyHeader and ScoreLevelSelector styles for 2xl screens

### DIFF
--- a/clients/assessment_component/src/assessment/pages/AssessmentPage/components/AssessmentForm/AssessmentForm.tsx
+++ b/clients/assessment_component/src/assessment/pages/AssessmentPage/components/AssessmentForm/AssessmentForm.tsx
@@ -212,7 +212,7 @@ export const AssessmentForm = ({
         )}
       >
         <CompetencyHeader
-          className='lg:col-span-2 2xl:col-span-1'
+          className='lg:col-span-2'
           competency={competency}
           competencyScore={assessment}
           completed={completed}
@@ -220,7 +220,7 @@ export const AssessmentForm = ({
         />
 
         <ScoreLevelSelector
-          className='lg:col-span-2 2xl:col-span-4 grid grid-cols-1 lg:grid-cols-5 gap-1'
+          className='lg:col-span-2 grid grid-cols-1 lg:grid-cols-5 gap-1'
           competency={competency}
           selectedScore={selectedScore}
           onScoreChange={handleScoreChange}


### PR DESCRIPTION
## ✨ What is the change?

Fixes a bug where the competency header only takes half width on 2xl

## 📌 Reason for the change / Link to issue

closes #935 

## 🧪 How to Test

<!-- List the steps someone should follow to test this PR. -->

1. Go to the assessment page
2. put your screen on 2xl

## ✅ PR Checklist

- [x] Tested locally or on the dev environment
- [x] Code is clean, readable, and documented
- [x] Tests added or updated (if needed)
- [x] Screenshots attached for UI changes (if any)
- [x] Documentation updated (if relevant)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Simplified responsive layout behavior on extra-large displays to improve layout consistency across different screen sizes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->