### PR TITLE
HotFix: ensure action menu stays open during confirmation modal

### DIFF
--- a/clients/shared_library/components/pages/CoursePhaseParticipationsTable/components/Actions/DropdownMenuItemForActionOnParticipants.tsx
+++ b/clients/shared_library/components/pages/CoursePhaseParticipationsTable/components/Actions/DropdownMenuItemForActionOnParticipants.tsx
@@ -47,7 +47,13 @@ export const DropdownMenuItemForActionOnParticipants = ({
 
   return (
     <>
-      <DropdownMenuItem onClick={handleTrigger} disabled={disabled}>
+      <DropdownMenuItem
+        disabled={disabled}
+        onSelect={(event) => {
+          event.preventDefault()
+          handleTrigger()
+        }}
+      >
         {action.icon}
         {action.label}
       </DropdownMenuItem>


### PR DESCRIPTION
## ✨ What is the change?

We make sure that triggering an action inside the action menu, will not cause the ActionMenu to instantly close. This is to make sure that the action menu stays there for actions that need confirmation. the handleTrigger() method handles closing in all cases

The root of the issue was → Action inside action menu triggered → causes action menu to close → if the action requires confirmation this would render the confirmation dialog, however it would instantly be removed from dom the moment the action menu would close.
Now → Keep menu open while interacting with confirmation dialog.

## 📌 Reason for the change / Link to issue

Fixes #953 

## 🧪 How to Test

1. Run clients and server on this branch
2. trigger a confirmable action inside any course phase particants table.

## 🖼️ Screenshots (if UI changes are included)
/

## ✅ PR Checklist

- [x] Tested locally or on the dev environment
- [x] Code is clean, readable, and documented
- [x] Tests added or updated (if needed)
- [x] Screenshots attached for UI changes (if any)
- [x] Documentation updated (if relevant)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved dropdown menu selection handling for course participation actions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->