### PR TITLE
`General`: Fix navigation redirection for logged-in users on About, Imprint, and Privacy pages

### DIFF
--- a/clients/core/src/publicPages/legalPages/AboutPage.tsx
+++ b/clients/core/src/publicPages/legalPages/AboutPage.tsx
@@ -24,9 +24,11 @@ import {
 import { Link, useNavigate } from 'react-router-dom'
 import { ContributorList } from './components/ContributorList'
 import { env } from '@/env'
+import { useAuthStore } from '@tumaet/prompt-shared-state'
 
 export default function AboutPage() {
   const navigate = useNavigate()
+  const { user } = useAuthStore()
 
   const coreFeatures = [
     {
@@ -82,7 +84,7 @@ export default function AboutPage() {
             variant='ghost'
             size='icon'
             className='absolute left-4 top-4 hover:bg-gray-100 transition-colors'
-            onClick={() => navigate('/')}
+            onClick={() => navigate(user ? '/management' : '/')}
             aria-label='Go back'
           >
             <ArrowLeft className='h-5 w-5' />

--- a/clients/core/src/publicPages/legalPages/Imprint.tsx
+++ b/clients/core/src/publicPages/legalPages/Imprint.tsx
@@ -10,9 +10,11 @@ import { ArrowLeft } from 'lucide-react'
 import { useNavigate } from 'react-router-dom'
 import { useEffect, useState } from 'react'
 import DOMPurify from 'dompurify'
+import { useAuthStore } from '@tumaet/prompt-shared-state'
 
 export default function ImprintPage() {
   const navigate = useNavigate()
+  const { user } = useAuthStore()
   const [content, setContent] = useState('')
 
   DOMPurify.addHook('afterSanitizeAttributes', function (node) {
@@ -42,7 +44,7 @@ export default function ImprintPage() {
             variant='ghost'
             size='icon'
             className='absolute left-4 top-4'
-            onClick={() => navigate('/')}
+            onClick={() => navigate(user ? '/management' : '/')}
             aria-label='Go back'
           >
             <ArrowLeft className='h-4 w-4' />

--- a/clients/core/src/publicPages/legalPages/Privacy.tsx
+++ b/clients/core/src/publicPages/legalPages/Privacy.tsx
@@ -10,9 +10,11 @@ import { ArrowLeft } from 'lucide-react'
 import { useNavigate } from 'react-router-dom'
 import { useEffect, useState } from 'react'
 import DOMPurify from 'dompurify'
+import { useAuthStore } from '@tumaet/prompt-shared-state'
 
 export default function PrivacyPage() {
   const navigate = useNavigate()
+  const { user } = useAuthStore()
   const [content, setContent] = useState('')
 
   DOMPurify.addHook('afterSanitizeAttributes', function (node) {
@@ -42,7 +44,7 @@ export default function PrivacyPage() {
             variant='ghost'
             size='icon'
             className='absolute left-4 top-4'
-            onClick={() => navigate('/')}
+            onClick={() => navigate(user ? '/management' : '/')}
             aria-label='Go back'
           >
             <ArrowLeft className='h-4 w-4' />


### PR DESCRIPTION
# 📝 Fix navigation for About, Imprint and Privacy

## ✨ What is the change?

- when a logged-in user goes back to PROMPT from the About, Imprint and Privacy page, it no longer falsely directs to the landing page, but the management dashboard

## 📌 Reason for the change / Link to issue

closes #972 

## 🧪 How to Test

1. Go on Dev
2. Log in
3. Go on one of the three legal pages
4. go back

## ✅ PR Checklist

- [x] Tested locally or on the dev environment
- [x] Code is clean, readable, and documented
- [x] Tests added or updated (if needed)
- [x] Screenshots attached for UI changes (if any)
- [x] Documentation updated (if relevant)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved back button behavior on legal pages. Authenticated users are now routed to the management section, while unauthenticated users are directed to the home page.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->