### PR TITLE
Remove Default 'New' from new course phases

### DIFF
--- a/clients/core/src/managementConsole/courseConfigurator/handlers/useDrop.ts
+++ b/clients/core/src/managementConsole/courseConfigurator/handlers/useDrop.ts
@@ -38,7 +38,7 @@ export const useDrop = (reactFlowWrapper, setNodes, setIsModified) => {
         const coursePhase: CoursePhaseWithPosition = {
           id: id,
           courseID: courseId ?? 'no-valid-id',
-          name: `${coursePhaseType.name}`,
+          name: coursePhaseType.name,
           position: position,
           isInitialPhase: coursePhaseType.initialPhase,
           coursePhaseTypeID: coursePhaseType.id,


### PR DESCRIPTION
## ✨ What is the change?

Creating a new phase no longer adds the prefix "New" by default.

## 📌 Reason for the change / Link to issue

## 🧪 How to Test

1. Clone the branch
2. Drag in a new course phase into the course configurator
3. Notice the name has no "New"

## 🖼️ Screenshots (if UI changes are included)

<img width="1484" height="988" alt="2026-01-31 at 21 38 51@2x" src="https://github.com/user-attachments/assets/3adb2f1b-a2c5-487d-9ee8-e935d32b3bda" />

## ✅ PR Checklist

- [x] Tested locally or on the dev environment
- [x] Code is clean, readable, and documented
- [x] Tests added or updated (if needed)
- [x] Screenshots attached for UI changes (if any)
- [x] Documentation updated (if relevant)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed course phase naming in the course configurator to display correct names without unintended prefixes.

* **New Features**
  * Enhanced course phase configuration with additional metadata fields for improved data organization and management.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->