### PR TITLE
`Core/Application` Fix redirection for missing application phase deadlines

### DIFF
--- a/clients/core/src/managementConsole/applicationAdministration/pages/ApplicationLandingPage/hooks/useMissingConfig.ts
+++ b/clients/core/src/managementConsole/applicationAdministration/pages/ApplicationLandingPage/hooks/useMissingConfig.ts
@@ -17,7 +17,7 @@ export const useMissingConfigs = (
       missingConfigItems.push({
         title: 'Application Phase Deadlines',
         icon: CalendarX,
-        link: `${path}/configuration`,
+        link: `${path}/settings`,
       })
     }
 


### PR DESCRIPTION
## ✨ What is the change?

Adjust link for missing application config

## 📌 Reason for the change / Link to issue

fixes #1052

## 🧪 How to Test

1. Visit the Application Administration page, with the application phase deadlines not configured
2. Notice the unconfigured alert now redirects to /settings (a working page)

## 🖼️ Screenshots (if UI changes are included)

## ✅ PR Checklist

- [x] Tested locally or on the dev environment
- [x] Code is clean, readable, and documented
- [x] Tests added or updated (if needed)
- [x] Screenshots attached for UI changes (if any)
- [x] Documentation updated (if relevant)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the navigation link for missing application phase deadline configurations to direct users to the correct settings page.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->