### PR TITLE
`Application`: Add required star to nationality field

### DIFF
--- a/clients/core/src/publicPages/application/pages/ApplicationForm/components/StudentForm/StudentForm.tsx
+++ b/clients/core/src/publicPages/application/pages/ApplicationForm/components/StudentForm/StudentForm.tsx
@@ -278,7 +278,7 @@ export const StudentForm = forwardRef<StudentComponentRef, StudentFormProps>(fun
             name='nationality'
             render={({ field }) => (
               <FormItem>
-                <FormLabel>Nationality</FormLabel>
+                <FormLabel>Nationality{requiredStar}</FormLabel>
                 <Popover>
                   <PopoverTrigger asChild>
                     <FormControl>


### PR DESCRIPTION
# 📝 Pull Request Template

Use this template to provide all necessary information for reviewing and testing your changes.

## ✨ What is the change?

Added the required red star indicator to the `Nationality` field label in the application registration student form.

## 📌 Reason for the change / Link to issue

The `Nationality` field is validated as required during registration, but the form label did not visually indicate that requirement.

## 🧪 How to Test

1. Open the public application form.
2. Go to the student information section.
3. Verify that the `Nationality` label now shows the red `*` required marker.

## 🖼️ Screenshots (if UI changes are included)

| Before         | After         |
| -------------- | ------------- |
|                |               |

## ✅ PR Checklist

- [ ] Tested locally or on the dev environment
- [x] Code is clean, readable, and documented
- [ ] Tests added or updated (if needed)
- [ ] Screenshots attached for UI changes (if any)
- [ ] Documentation updated (if relevant)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the student application form to enhance clarity by adding a required field indicator to the nationality field label, making it more apparent which fields must be completed during the application process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->