### PR TITLE
`Assessment`: Show category and competency weights in settings

### DIFF
--- a/clients/assessment_component/src/assessment/pages/SettingsPage/components/CategoryList/components/CompetencyItem/CompetencyItem.tsx
+++ b/clients/assessment_component/src/assessment/pages/SettingsPage/components/CategoryList/components/CompetencyItem/CompetencyItem.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 import { Edit, Trash2 } from 'lucide-react'
 
-import { Button } from '@tumaet/prompt-ui-components'
+import { Button, Badge } from '@tumaet/prompt-ui-components'
 
 import { AssessmentType } from '../../../../../../interfaces/assessmentType'
 import { Competency } from '../../../../../../interfaces/competency'
@@ -58,7 +58,12 @@ export const CompetencyItem = ({
     <div>
       <div className='rounded-md border p-4 space-y-4'>
         <div className='flex justify-between items-center gap-2'>
-          <h3 className='text-base font-medium'>{competency.name}</h3>
+          <div className='flex flex-wrap items-center gap-2'>
+            <h3 className='text-base font-medium'>{competency.name}</h3>
+            <Badge className='h-5 px-2 text-xs font-medium bg-slate-100 text-slate-700 border-slate-200 hover:bg-slate-100'>
+              Weight: {competency.weight}
+            </Badge>
+          </div>
 
           <div className='flex'>
             <Button


### PR DESCRIPTION
## ✨ What is the change?

- Added a compact badge in Assessment Settings competency rows to show weights in the format `Weight: <Category> / <Competency>`.
- Removed the separate category-level weight badge to keep the settings view concise.

## 📌 Reason for the change / Link to issue

- Makes category and competency weighting visible directly where competencies are configured.
- Improves usability by reducing the need to open edit dialogs just to inspect weights.

## 🧪 How to Test

1. Open Assessment Settings as a user with schema editing access.
2. Expand a category in the Assessment Schema section.
3. Verify each competency shows a badge like `Weight: <category weight> / <competency weight>`.
4. Verify no separate category-weight badge is shown in the category header.
5. Verify existing category and competency edit/delete actions still work.

## 🖼️ Screenshots (if UI changes are included)



## ✅ PR Checklist

- [ ] Tested locally or on the dev environment
- [x] Code is clean, readable, and documented
- [ ] Tests added or updated (if needed)
- [ ] Screenshots attached for UI changes (if any)
- [ ] Documentation updated (if relevant)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Competency items in Settings now display Weight badges alongside competency names. This enhancement provides immediate visibility of competency weights within the Competency List, improving clarity when reviewing assessment settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->