### PR TITLE
`Interview`: Fix long location overflow

### DIFF
--- a/clients/interview_component/src/interview/components/StudentCard.tsx
+++ b/clients/interview_component/src/interview/components/StudentCard.tsx
@@ -75,12 +75,12 @@ export function StudentCard({ participation, interviewSlot }: StudentCardProps) 
                     href={interviewSlot.location}
                     target='_blank'
                     rel='noopener noreferrer'
-                    className='text-blue-600 hover:underline truncate break-all'
+                    className='text-blue-600 hover:underline truncate min-w-0'
                   >
                     {interviewSlot.location}
                   </a>
                 ) : (
-                  <span className='truncate'>{interviewSlot.location}</span>
+                  <span className='truncate min-w-0'>{interviewSlot.location}</span>
                 )}
               </div>
             )}

--- a/clients/interview_component/src/interview/pages/ScheduleManagement/InterviewScheduleManagement.tsx
+++ b/clients/interview_component/src/interview/pages/ScheduleManagement/InterviewScheduleManagement.tsx
@@ -570,12 +570,12 @@ export const InterviewScheduleManagement = () => {
                                 href={slot.location}
                                 target='_blank'
                                 rel='noopener noreferrer'
-                                className='text-blue-600 hover:underline truncate break-all'
+                                className='text-blue-600 hover:underline truncate min-w-0'
                               >
                                 {slot.location}
                               </a>
                             ) : (
-                              <span className='truncate'>{slot.location}</span>
+                              <span className='truncate min-w-0'>{slot.location}</span>
                             )}
                           </div>
                         ) : (

--- a/clients/interview_component/src/interview/pages/StudentInterview/StudentInterviewPage.tsx
+++ b/clients/interview_component/src/interview/pages/StudentInterview/StudentInterviewPage.tsx
@@ -252,12 +252,12 @@ export const StudentInterviewPage = () => {
                           href={slot.location}
                           target='_blank'
                           rel='noopener noreferrer'
-                          className='text-blue-600 hover:underline truncate break-all'
+                          className='text-blue-600 hover:underline truncate min-w-0'
                         >
                           {slot.location}
                         </a>
                       ) : (
-                        <span className='truncate'>{slot.location}</span>
+                        <span className='truncate min-w-0'>{slot.location}</span>
                       )}
                     </div>
                   )}


### PR DESCRIPTION
## ✨ What is the change?

Fixed the location field display in interview scheduling to properly handle URLs. When the location contains a URL, it is now rendered as a clickable link with proper styling while preventing the MapPin icon from disappearing and preventing text overflow on smaller screens.

## 📌 Reason for the change / Link to issue

closes #1187 #1185

When a location field contained a URL, the MapPin icon would disappear and the URL would overflow the card boundaries on smaller screens.

## 🧪 How to Test

1. Navigate to interview scheduling page
2. Create or view an interview slot with a URL in the location field (e.g., https://example.com/meeting)
3. Verify the MapPin icon is visible next to the location
4. Verify the URL is clickable and opens in a new tab
5. Resize the browser window to a smaller size and verify the URL doesn't overflow the card
6. Test with non-URL locations to ensure they still display correctly

## 🖼️ Screenshots (if UI changes are included)

<!-- Include before/after screenshots if this PR involves any visual changes. -->

| Before         | After         |
| -------------- | ------------- |
| <img width="522" height="443" alt="Bildschirmfoto 2026-02-17 um 09 33 55" src="https://github.com/user-attachments/assets/6f6ad5df-ed0a-4d98-bf5b-7817873b8ae3" /> | <img width="513" height="416" alt="Bildschirmfoto 2026-02-17 um 09 35 23" src="https://github.com/user-attachments/assets/4cca2bf7-a975-44a7-92aa-6a0f192d64c8" /> |

## ✅ PR Checklist

- [x] Tested locally or on the dev environment
- [x] Code is clean, readable, and documented
- [x] Tests added or updated (if needed)
- [x] Screenshots attached for UI changes (if any)
- [x] Documentation updated (if relevant)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interview locations that are URLs (http/https) now display as clickable external links and open in a new tab.
  * Non-URL locations remain as truncated plain text for readability.
  * Improved visual spacing and truncation handling for location indicators across interview scheduling and student views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->