### PR TITLE
`Core`: Make Prompt logo clickable by linking to home screen

### DIFF
--- a/clients/core/src/managementConsole/layout/Sidebar/InsideSidebar/components/PromptLogo.tsx
+++ b/clients/core/src/managementConsole/layout/Sidebar/InsideSidebar/components/PromptLogo.tsx
@@ -5,7 +5,7 @@ export const PromptLogo = () => {
   const version = packageJSON.version
 
   return (
-    <Link to='/' className='flex items-center'>
+    <Link to='/' className='flex items-center hover:opacity-80 transition-opacity duration-150'>
       <img src='/prompt_logo.svg' alt='Prompt logo' className='size-8 -mr-1' />
       <div className='relative flex items-baseline'>
         <span className='text-lg font-extrabold tracking-wide text-primary drop-shadow-sm'>


### PR DESCRIPTION
## ✨ What is the change?

Make Prompt logo clickable by linking to home screen

## 📌 Reason for the change / Link to issue

<!-- Explain why this change was made. Optionally include a link to the relevant issue or ticket. -->

closes #1057

## 🧪 How to Test

<!-- List the steps someone should follow to test this PR. -->

1. Open Prompt
2. Click on the Logo

## 🖼️ Screenshots (if UI changes are included)

<!-- Include before/after screenshots if this PR involves any visual changes. -->

only visual changes

## ✅ PR Checklist

- [ ] Tested locally or on the dev environment
- [x] Code is clean, readable, and documented
- [x] Tests added or updated (if needed)
- [ ] Screenshots attached for UI changes (if any)
- [ ] Documentation updated (if relevant)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Logo is now clickable and navigates to the home page when selected.

* **Style**
  * Added hover styling to the logo link for improved visual feedback; inner logo appearance and layout remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->