### PR TITLE
`Team Allocation`: Fix survey not updated when number of teams changes after survey started

### DIFF
--- a/clients/team_allocation_component/src/team_allocation/pages/StudentSurvey/components/SurveyForm.tsx
+++ b/clients/team_allocation_component/src/team_allocation/pages/StudentSurvey/components/SurveyForm.tsx
@@ -40,8 +40,6 @@ export const SurveyFormComponent = ({ surveyForm, surveyResponse, isStudent }: S
 
     const currentTeamIDs = new Set(surveyForm.teams.map((t) => t.id))
 
-    // Initialize team ranking: use the saved preferences if they still match the current team list;
-    // otherwise fall back to a fresh randomized order so the student can re-rank after team changes.
     let newTeamRanking: string[]
     if (surveyResponse?.teamPreferences?.length) {
       const sorted = [...surveyResponse.teamPreferences].sort((a, b) => a.preference - b.preference)
@@ -53,7 +51,6 @@ export const SurveyFormComponent = ({ surveyForm, surveyResponse, isStudent }: S
       if (savedMatchCurrent) {
         newTeamRanking = savedTeamIDs
       } else {
-        // Teams have changed since the last submission — re-initialize with current teams
         newTeamRanking = surveyForm.teams.map((team) => team.id).sort(() => Math.random() - 0.5)
       }
     } else {
@@ -63,8 +60,6 @@ export const SurveyFormComponent = ({ surveyForm, surveyResponse, isStudent }: S
     setTeamRanking(newTeamRanking)
     setInitialTeamRanking(newTeamRanking)
 
-    // Initialize skill ratings: use saved responses if available and the skill is still valid;
-    // skills that were removed since the last submission are dropped.
     const currentSkillIDs = new Set(surveyForm.skills.map((s) => s.id))
     const newSkillRatings: Record<string, SkillLevel | undefined> = {}
     if (surveyResponse?.skillResponses?.length) {


### PR DESCRIPTION
## ✨ What is the change?

When an admin changes the number of teams after a student has already submitted the survey, the form now re-initializes with the current team list instead of the stale saved response. The same fix is applied to skills.

## 📌 Reason for the change / Link to issue

Fixes #451 — if a student had already submitted and the admin later added or removed teams, the student's saved preferences contained stale team IDs. On resubmit, the backend validation compared the submission against the current DB state and returned a mismatch error, blocking the student from resubmitting.

**Root cause:** `SurveyForm.tsx` always initialized `teamRanking` from the saved response without checking whether those team IDs still matched the current survey form.

**Fix:** Before using saved preferences, validate that the saved team IDs exactly match the current team list (same count, same IDs). If they don't match, discard the stale ranking and re-initialize from the current survey form. Stale skill ratings are similarly filtered to only include skills that still exist.

## 🧪 How to Test

1. Start a survey with N teams.
2. Have a student submit their team preferences.
3. As an admin, add or remove a team.
4. Have the student reload the survey page.
5. Verify the team ranking resets to the updated team list.
6. Verify the student can re-submit successfully without a mismatch error.

## 🖼️ Screenshots (if UI changes are included)

No visual changes — the form appearance is identical; the only difference is that after a team list change the ranking resets to the new team list instead of showing stale data.

## ✅ PR Checklist

- [x] Tested locally or on the dev environment
- [x] Code is clean, readable, and documented
- [ ] Tests added or updated (if needed)
- [ ] Screenshots attached for UI changes (if any)
- [ ] Documentation updated (if relevant)