### PR TITLE
`Application`: Fix breadcrumbs showing 'Participant' instead of name on Application Details page

### DIFF
--- a/clients/core/src/managementConsole/layout/Breadcrumbs/Breadcrumbs.tsx
+++ b/clients/core/src/managementConsole/layout/Breadcrumbs/Breadcrumbs.tsx
@@ -97,9 +97,13 @@ export const Breadcrumbs: React.FC = () => {
                 const participation = participations.find(
                   (p) => p.courseParticipationID === segment,
                 )
-                const title = participation
-                  ? `${participation.student.firstName} ${participation.student.lastName}`
-                  : 'Participant'
+                const fullName = [
+                  participation?.student?.firstName ?? '',
+                  participation?.student?.lastName ?? '',
+                ]
+                  .filter(Boolean)
+                  .join(' ')
+                const title = fullName || 'Participant'
                 breadcrumbs.push({
                   title,
                   path: `/management/course/${courseId}/${phaseId}/${pathSegments.slice(4, index + 5).join('/')}`,


### PR DESCRIPTION
## ✨ What is the change?

In the Application Details page, the breadcrumb for a participant was hardcoded to `"Participant"` instead of showing the actual person's name. This fix looks up the participant in the `useApplicationStore` by `courseParticipationID` and displays their `firstName lastName` instead.

## 📌 Reason for the change / Link to issue

Closes #1209

## 🧪 How to Test

1. Navigate to a course phase that uses the application administration (e.g. an intro course phase)
2. Open the participants table
3. Click on a participant to open the Application Details page
4. Verify the breadcrumb shows the participant's name (e.g. "Jane Doe") instead of "Participant"

## 🖼️ Screenshots (if UI changes are included)

<!-- Include before/after screenshots if this PR involves any visual changes. -->

| Before         | After         |
| -------------- | ------------- |
| Breadcrumb shows "Participant" | Breadcrumb shows the participant's actual name |

## ✅ PR Checklist

- [x] Tested locally or on the dev environment
- [x] Code is clean, readable, and documented
- [ ] Tests added or updated (if needed)
- [x] Screenshots attached for UI changes (if any)
- [ ] Documentation updated (if relevant)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Breadcrumb navigation now displays participant names instead of generic labels, providing more informative course path navigation. Falls back to a default label when participant information is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->