### PR TITLE
`Auth`: Improve keycloak developer experience

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -474,6 +474,7 @@ services:
     container_name: prompt-keycloak
     command:
       - start-dev
+      - --import-realm
       - --health-enabled=true
       - --hostname-strict=false
     environment:
@@ -484,6 +485,7 @@ services:
       KC_DB_PASSWORD: ${KEYCLOAK_DB_PASSWORD}
       KEYCLOAK_ADMIN: ${KEYCLOAK_ADMIN}
       KEYCLOAK_ADMIN_PASSWORD: ${KEYCLOAK_ADMIN_PASSWORD}
+      KC_IMPORT_REALM: /opt/keycloak/data/import/realm.json
       KC_HOSTNAME: "localhost"
       KC_HOSTNAME_PORT: "8081"
       KC_HOSTNAME_STRICT: "false"
@@ -496,6 +498,8 @@ services:
     ports:
       - "8081:8080"
       - "9000:9000"
+    volumes:
+      - ./keycloakConfig.json:/opt/keycloak/data/import/realm.json:ro
     healthcheck:
       test: ["CMD-SHELL", "exec 4<>/dev/tcp/localhost/9000"]
       interval: 30s

--- a/docs/admin/keycloak-prod.md
+++ b/docs/admin/keycloak-prod.md
@@ -1,0 +1,133 @@
+> [!IMPORTANT]
+> **Scope of this Guide:** This documentation applies to repository-managed Keycloak instances and self-hosted production deployments. 
+> 
+> Note that the official **PROMPT** production instance managed by the **AET (Applied Education Technologies)** team uses an external identity provider. Changes to `keycloakConfig.json` in this repository do not affect the central AET Keycloak service.
+
+This document provides instructions for deploying, securing, and maintaining Keycloak in a production environment for the **PROMPT 2.0** platform.
+
+---
+
+## 1. Production Configuration Guide
+When moving from development to production, Keycloak must be optimized for the Quarkus-based distribution.
+
+### Core Environment Variables
+| Variable | Value | Description |
+| :--- | :--- | :--- |
+| `KC_PROXY_HEADERS` | `xforwarded` | Trust `X-Forwarded-*` headers from a TLS-terminating reverse proxy (Nginx/Traefik). |
+| `KC_HOSTNAME` | `sso.yourdomain.com` | Strict hostname for security and redirect validation. |
+| `KC_DB` | `postgres` | Database vendor. |
+| `KC_HTTP_ENABLED` | `true` | Keep HTTP enabled behind the proxy; TLS is terminated at the reverse proxy. |
+
+---
+
+## 2. Security Best Practices
+Protecting the Identity Provider is the foundation of PROMPT's security.
+
+### Hardening Checklist
+* **Change Default Credentials:** Immediately rotate the `KEYCLOAK_ADMIN_PASSWORD` and `KEYCLOAK_CLIENT_SECRET`.
+* **SSL/TLS Setup:** Ensure the reverse proxy uses TLS 1.3 and strong cipher suites. Keycloak should never be exposed directly to the internet via HTTP.
+* **Brute Force Protection:** * Navigate to **Realm Settings** -> **Security Defenses**.
+    * Enable **Brute Force Detection**.
+    * Set **Max Login Failures** (e.g., 5) and **Wait Increment** to prevent automated password guessing.
+* **Master Realm Isolation:** Use the `master` realm *only* for managing Keycloak itself. All PROMPT users and clients must reside in the `prompt` realm.
+
+---
+
+## 3. Role and Permission Management
+
+PROMPT uses a hybrid Role-Based Access Control (RBAC) model consisting of static global roles and dynamic course-level roles.
+
+### A. Global System Roles
+These roles are static and grant high-level permissions across the entire platform. Assign these directly in Keycloak:
+
+| Role Name | Description |
+| :--- | :--- |
+| `PROMPT_Admin` | Full system orchestration, global settings, and user management. |
+| `PROMPT_Lecturer` | Global teaching authority; allowed to create new courses and manage departments. |
+
+### B. Course-Specific Roles
+Permissions for specific courses are validated using a dynamic naming convention. The backend expects roles to be formatted exactly as:
+`<semester>-<course_name>-<role>`
+
+**Examples:**
+- `Winter2024-Algorithms101-Lecturer`
+- `Summer2025-MobileAppDev-Editor`
+- `Winter2024-Algorithms101-Student`
+
+> [!CAUTION]
+> **Do not use the `PROMPT_` prefix for course-level roles.** If a course is named "IntroToAI" in the "Summer2026" semester, the student role **must** be `Summer2026-IntroToAI-Student`. Any other format will result in an authorization failure.
+
+### C. Role Assignment Strategy
+1. **Global Roles:** Assign to permanent staff via **Role Mapping**.
+2. **Course Roles:** These are typically created and assigned dynamically during the course enrollment process. If manual setup is required, ensure the string matches the `<semester>-<course_name>-<role>` pattern defined in the backend configuration.
+---
+
+## 4. User Provisioning and Group Management
+### Provisioning Strategies
+1. **Manual:** Via the Admin Console (**Users** -> **Add user**).
+2. **Federated:** Automatic syncing from LDAP/AD (recommended for universities).
+3. **Self-Registration:** Can be enabled in **Realm Settings** -> **Login**, but usually discouraged for managed courses.
+
+### Group Management
+Use **Groups** to apply roles in bulk. For example, create a group `PROMPT-Admins` and map the `PROMPT_Admin` role to it. Every user added to this group inherits the role automatically.
+
+---
+
+## 5. Client Mapper Configuration
+The Go backend requires specific user attributes to be present in the JWT token.
+
+### Required Custom Mappers
+Configure these in **Clients** -> **prompt-server** -> **Client scopes** -> **prompt-server-dedicated**:
+
+| Name | Mapper Type | User Attribute | Token Claim Name |
+| :--- | :--- | :--- | :--- |
+| `university_login` | User Attribute | `university_login` | `university_login` |
+| `matriculation_number` | User Attribute | `matriculation_number` | `matriculation_number` |
+
+> **Note:** Without these mappers, the backend will return `401 Unauthorized` or fail to link the user to the database.
+
+---
+
+## 6. Realm Configuration Options
+* **Themes:** Set custom themes for Login, Account, and Admin pages in **Realm Settings** -> **Themes**.
+* **Email:** Configure a valid SMTP server in **Realm Settings** -> **Email** to support "Forgot Password" and email verification flows.
+* **Tokens:** Adjust **Access Token Lifespan** (recommended: 5-15 minutes) and **SSO Session Max** to balance security and user experience.
+
+---
+
+## 7. Integration with External Identity Providers (IDP)
+PROMPT is designed to integrate with institutional authentication systems.
+
+### LDAP / Active Directory
+1. Go to **User Federation** -> **Add provider** -> **ldap**.
+2. Map institutional `uid` or `sAMAccountName` to Keycloak's `university_login`.
+3. Set **Sync Registrations** to keep Keycloak in sync with the university directory.
+
+### SAML 2.0 / OIDC
+1. Go to **Identity Providers** -> **Add SAML v2.0 provider**.
+2. Import metadata from your institution (e.g., Shibboleth).
+3. Use **Mappers** to extract the user's login and roles from the SAML assertion.
+
+---
+
+## 8. Backup and Restore Procedures
+### Database Backup (PostgreSQL)
+Run a daily cron job to dump the Keycloak database:
+```bash
+docker exec prompt-keycloak-db \
+  pg_dump -U "${KEYCLOAK_DB_USER}" "${KEYCLOAK_DB_NAME}" \
+  > backup_$(date +%F).sql
+ ```
+
+### Database Restore (PostgreSQL)
+Stop Keycloak, drop and recreate the database, then restore:
+```bash
+docker compose stop keycloak
+docker exec -i prompt-keycloak-db \
+  psql -U "${KEYCLOAK_DB_USER}" -d postgres \
+  -c "DROP DATABASE IF EXISTS ${KEYCLOAK_DB_NAME};" \
+  -c "CREATE DATABASE ${KEYCLOAK_DB_NAME};"
+docker exec -i prompt-keycloak-db \
+  psql -U "${KEYCLOAK_DB_USER}" -d "${KEYCLOAK_DB_NAME}" < backup_YYYY-MM-DD.sql
+docker compose start keycloak
+```

--- a/docs/contributor/keycloak-dev.md
+++ b/docs/contributor/keycloak-dev.md
@@ -1,0 +1,38 @@
+# Keycloak Local Development Guide
+
+## 1. Local Setup (Step-by-Step)
+1. **Launch Containers:** Use `docker-compose up -d keycloak keycloak-db`. 
+2. **Auto-Import:** The system is configured to import `keycloakConfig.json` automatically on startup.
+3. **Verify:** Access the UI at `http://localhost:8081`.
+
+## 2. Pre-configured Test Users
+
+The following accounts are included in `keycloakConfig.json` to facilitate testing of various permission levels within the PROMPT platform.
+
+| Username | Password | University Login | Matriculation Number | Client Role (`prompt-server`) |
+| :--- | :--- | :--- | :--- | :--- |
+| **admin** | `admin` | `ad12min` | `00000001` | `PROMPT_Admin` |
+| **lecturer** | `lecturer` | `le50ctu` | `00000002` | `PROMPT_Lecturer` |
+| **course-lecturer** | `course-lecturer` | `co67lec` | `00000003` | `PROMPT_Course_Lecturer` |
+| **course-editor** | `course-editor` | `co69edt` | `00000004` | `PROMPT_Course_Editor` |
+| **student** | `student` | `no42tum` | `00000005` | `PROMPT_Student` |
+| **student-passkey** | `student-passkey` | `no43tum` | `00000006` | `PROMPT_Student` |
+
+## 3. Modifying Users and Roles
+- **Adding Users:** Go to `Users` -> `Add user`. Required fields: Username, Email, First/Last Name.
+- **Assigning Roles:** Go to `Users` -> pick user -> go to `Role Mapping` tab and `Assign role`.
+
+## 4. Manual Client Mapper Configuration
+If you need to manually add mappers for `prompt-server`:
+1. Go to `Clients` -> `prompt-server` -> `Client scopes`.
+2. Click `prompt-server-dedicated` -> `Add mapper` -> `By configuration`.
+3. Choose `User Attribute`.
+4. Example (University Login):
+   - Name: `university_login`
+   - User Attribute: `university_login`
+   - Token Claim Name: `university_login`
+
+## 5. Troubleshooting & Reset
+- **Reset to Default:** Run `docker-compose down -v` and `rm -rf keycloak_postgres_data`. This wipes the DB and re-imports the JSON on next Keycloak start.
+- **401 Unauthorized:** Check if `KEYCLOAK_CLIENT_SECRET` in `.env.dev` matches the one in Keycloak UI.
+- **Passkey Issues:** Ensure `Resident Key` is `Required` in WebAuthn Passwordless Policy.

--- a/keycloakConfig.json
+++ b/keycloakConfig.json
@@ -490,7 +490,7 @@
     "webAuthnPolicyPasswordlessSignatureAlgorithms": [
       "ES256"
     ],
-    "webAuthnPolicyPasswordlessRpId": "",
+    "webAuthnPolicyPasswordlessRpId": "localhost",
     "webAuthnPolicyPasswordlessAttestationConveyancePreference": "not specified",
     "webAuthnPolicyPasswordlessAuthenticatorAttachment": "not specified",
     "webAuthnPolicyPasswordlessRequireResidentKey": "not specified",
@@ -519,6 +519,111 @@
         },
         "notBefore": 0,
         "groups": []
+      },
+      {
+        "username": "admin",
+        "email": "admin@example.com",
+        "firstName": "Admin",
+        "lastName": "Admin",
+        "createdTimestamp": 1737552859689,
+        "emailVerified": true,
+        "enabled": true,
+        "credentials": [{ "type": "password", "value": "admin", "temporary": false }],
+        "attributes": {
+          "university_login": ["ad12min"],
+          "matriculation_number": ["00000001"]
+        },
+        "clientRoles": {
+          "prompt-server": ["PROMPT_Admin"],
+          "realm-management": ["realm-admin"]
+        },
+        "groups": ["Prompt-Admins"]
+      },
+      {
+        "username": "lecturer",
+        "firstName": "Lector",
+        "lastName": "Lector",
+        "email": "lecturer@example.com",
+        "createdTimestamp": 1737552859689,
+        "emailVerified": true,
+        "enabled": true,
+        "credentials": [{ "type": "password", "value": "lecturer", "temporary": false }],
+        "attributes": {
+          "university_login": ["le50ctu"],
+          "matriculation_number": ["00000002"]
+        },
+        "clientRoles": {
+          "prompt-server": ["PROMPT_Lecturer"]
+        }
+      },
+      {
+        "username": "course-lecturer",
+        "firstName": "Lector",
+        "lastName": "Lector",
+        "email": "of_course-lecturer@example.com",
+        "createdTimestamp": 1737552859689,
+        "emailVerified": true,
+        "enabled": true,
+        "credentials": [{ "type": "password", "value": "course-lecturer", "temporary": false }],
+        "attributes": {
+          "university_login": ["co67lec"],
+          "matriculation_number": ["00000003"]
+        },
+        "clientRoles": {
+          "prompt-server": ["PROMPT_Course_Lecturer"]
+        }
+      },
+      {
+        "username": "course-editor",
+        "firstName": "Eduard",
+        "lastName": "Eduard",
+        "email": "best_edits@example.com",
+        "createdTimestamp": 1737552859689,
+        "emailVerified": true,
+        "enabled": true,
+        "credentials": [{ "type": "password", "value": "course-editor", "temporary": false }],
+        "attributes": {
+          "university_login": ["co69edt"],
+          "matriculation_number": ["00000004"]
+        },
+        "clientRoles": {
+          "prompt-server": ["PROMPT_Course_Editor"]
+        }
+      },
+      {
+        "username": "student",
+        "firstName": "Stan",
+        "lastName": "Stan",
+        "email": "pgdp_enjoyer@example.com",
+        "createdTimestamp": 1737552859689,
+        "emailVerified": true,
+        "enabled": true,
+        "credentials": [{ "type": "password", "value": "student", "temporary": false }],
+        "attributes": {
+          "university_login": ["no42tum"],
+          "matriculation_number": ["00000005"]
+        },
+        "clientRoles": {
+          "prompt-server": ["PROMPT_Student"]
+        }
+      },
+      {
+        "username": "student-passkey",
+        "firstName": "Paskal",
+        "lastName": "Paskal",
+        "email": "passkey_enjoyer@example.com",
+        "createdTimestamp": 1737552859689,
+        "emailVerified": true,
+        "enabled": true,
+        "requiredActions": ["webauthn-register-passwordless"], 
+        "credentials": [{ "type": "password", "value": "student-passkey", "temporary": false }],
+        "attributes": {
+          "university_login": ["no43tum"],
+          "matriculation_number": ["00000006"]
+        },
+        "clientRoles": {
+          "prompt-server": ["PROMPT_Student"]
+        }
       }
     ],
     "scopeMappings": [
@@ -2344,7 +2449,7 @@
         "name": "Webauthn Register Passwordless",
         "providerId": "webauthn-register-passwordless",
         "enabled": true,
-        "defaultAction": false,
+        "defaultAction": true,
         "priority": 80,
         "config": {}
       },

--- a/keycloakConfig.json
+++ b/keycloakConfig.json
@@ -2028,6 +2028,34 @@
         ]
       },
       {
+      "id": "e1b2c3d4-5e6f-7a8b-9c0d-112233445566",
+      "alias": "browser-passkey",
+      "description": "Browser flow with Passkey support",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": false,
+      "authenticationExecutions": [
+          {
+          "authenticator": "auth-cookie",
+          "requirement": "ALTERNATIVE",
+          "priority": 10,
+          "userSetupAllowed": false
+          },
+          {
+          "authenticator": "webauthn-authenticator-passwordless",
+          "requirement": "ALTERNATIVE",
+          "priority": 20,
+          "userSetupAllowed": true
+          },
+          {
+          "authenticator": "auth-username-password-form",
+          "requirement": "ALTERNATIVE",
+          "priority": 30,
+          "userSetupAllowed": false
+          }
+        ]
+      },
+      {
         "id": "c5b5120c-1085-41fa-ad20-725063b99c27",
         "alias": "browser",
         "description": "browser based authentication",
@@ -2463,7 +2491,7 @@
         "config": {}
       }
     ],
-    "browserFlow": "browser",
+    "browserFlow": "browser-passkey",
     "registrationFlow": "registration",
     "directGrantFlow": "direct grant",
     "resetCredentialsFlow": "reset credentials",

--- a/readme.md
+++ b/readme.md
@@ -197,9 +197,9 @@ To start a specific micro-frontend only, navigate to its subdirectory and run `y
 ---
 ### Keycloak Passkey Testing
 #### Option 1 (Preconfigured user with passkey): 
-Log in as a user with credentials  username: student-passkey | password: student-passkey
-You will be asked to register your passkey
-With next login you can use your registered passkey instead of password-based authentication
+Log in as a user with credentials  username: student-passkey | password: student-passkey.
+You will be asked to register your passkey.
+With next login you can use your registered passkey instead of password-based authentication.
 
 #### Option 2 (Configure passkey manually):
 #### 1. Enable Registration for a User
@@ -295,6 +295,7 @@ We are building a community around PROMPT! Whether you are an instructor using t
 We welcome contributions of all kinds! Please see our [Contributing Guidelines](./CONTRIBUTING.md) to get started.
 
 ---
+
 ## Configuration
 
 PROMPT can be customized for your course by composing it from different modular phases. These configurations are handled at the course level and dynamically loaded on demand.

--- a/readme.md
+++ b/readme.md
@@ -195,6 +195,51 @@ This launches all micro-frontends simultaneously using Lerna. The app runs at [h
 To start a specific micro-frontend only, navigate to its subdirectory and run `yarn run dev` there.
 
 ---
+### Keycloak Passkey Testing
+#### Option 1 (Preconfigured user with passkey): 
+Log in as a user with credentials  username: student-passkey | password: student-passkey
+You will be asked to register your passkey
+With next login you can use your registered passkey instead of password-based authentication
+
+#### Option 2 (Configure passkey manually):
+#### 1. Enable Registration for a User
+To test the flow, you must force a specific user to register their biometric data:
+
+Access Keycloak Admin: Go to http://localhost:8081 (Login: admin / admin).
+
+Select Realm: Ensure the Prompt realm is selected in the top-left corner.
+
+#### Configure User:
+
+Navigate to "Users" → Click on the user (e.g., student).
+
+In the "Details" tab, find "Required user actions" field.
+
+Select "Webauthn Register Passwordless".
+
+Click "Save".
+
+#### 2. Register the Passkey
+Open http://localhost:3000 and click "Login".
+
+Sign in using standard credentials (e.g., student / student).
+
+Keycloak will prompt you to register a passkey.
+
+Your browser/OS will prompt for user verification, such as Touch ID, Face ID, Windows Hello, a PIN, or a security key. Follow the prompts to complete registration.
+
+#### 3. Verify Passwordless Login
+Log out or open a new Incognito/Private window.
+
+Go to http://localhost:3000 → Login.
+
+Click "Try another way".
+
+Select "Passkey" → Sign in with Passkey.
+
+Use your new user verification method. You should be logged in instantly without entering a password.
+
+---
 
 ### Useful Commands
 

--- a/readme.md
+++ b/readme.md
@@ -295,7 +295,6 @@ We are building a community around PROMPT! Whether you are an instructor using t
 We welcome contributions of all kinds! Please see our [Contributing Guidelines](./CONTRIBUTING.md) to get started.
 
 ---
-
 ## Configuration
 
 PROMPT can be customized for your course by composing it from different modular phases. These configurations are handled at the course level and dynamically loaded on demand.


### PR DESCRIPTION
## ✨ What is the change?

Update: keycloakConfig.json is automaticaly imported with the start of keycloak container. 
Add: 
- 5 new test users and their according roles
- two client mappers: university_login, matriculation_number
- passkey/WebAuthn authentication
- contributor and admin documentation: admin/keycloak-prod.md and contributor/keycloak-dev.md

## 📌 Reason for the change / Link to issue

Issue 1102: closes #1102 

## 🧪 How to Test

1. Clean Restart: Stop your containers and wipe old Keycloak data: 
   docker-compose down -v && rm -rf keycloak_postgres_data && docker-compose up -d db keycloak-db keycloak`
2. Setup User: Log into [localhost:8081](http://localhost:8081) (admin/admin), go to user `student`, and add `Webauthn Register Passwordless` to Required User Actions.
3. Register Passkey: Go to [localhost:3000](http://localhost:3000), login with `student/student`, and register your TouchID/FaceID when prompted.
4. Verify Login: Logout, then select Login -> Try another way -> Passkey. You should be logged in instantly using only your biometrics.
5. Check Docs:*Verify that the new files in `/docs` are correctly linked in the main `README.md`.

## ✅ PR Checklist

- [X] Tested locally or on the dev environment
- [X] Code is clean, readable, and documented
- [ ] Tests added or updated (if needed)
- [ ] Screenshots attached for UI changes (if any)
- [X] Documentation updated (if relevant)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a DevOps Challenge microfrontend with pages for the challenge, results overview, mailing and student detail; management UI shows a new application link and sidebar entry.
  * Added passwordless passkey-enabled login flow, new prompt-realm roles, preconfigured users (including a passkey test user), and automatic realm import on startup.
  * Deployment: new Docker service and image support for the DevOps Challenge.

* **Documentation**
  * Production and local Keycloak guides, simplified setup, and passkey testing instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->