### PR TITLE
`Assessment`: Fix score options disappearing after selection

### DIFF
--- a/clients/assessment_component/src/assessment/pages/components/ScoreLevelSelector.tsx
+++ b/clients/assessment_component/src/assessment/pages/components/ScoreLevelSelector.tsx
@@ -118,6 +118,7 @@ export const ScoreLevelSelector = ({
       descriptionsByLevel={mapCompetencyDescriptionsByLevel(competency)}
       showIndicators={showIndicators}
       indicators={indicators}
+      hideUnselectedOnDesktop={false}
     />
   )
 }


### PR DESCRIPTION
## ✨ What is the change?

Pass `hideUnselectedOnDesktop={false}` to `BaseScoreLevelSelector` in `ScoreLevelSelector.tsx`.

## 📌 Reason for the change / Link to issue

Closes #1515.

In commit `36607334`, `ScoreLevelSelector` was refactored to delegate rendering to the shared `BaseScoreLevelSelector` component. That component defaults `hideUnselectedOnDesktop` to `true`, which applies `lg:hidden` to unselected options on desktop — the exact opposite of the previous behavior (`hidden lg:flex`: hidden on mobile, visible on desktop).

As a result, selecting a score on desktop caused all other options to disappear, making it impossible to correct a mistaken selection without resetting the entire assessment.

## 🧪 How to Test

1. Open the assessment grading view for a student
2. Select a score option (e.g. "Disagree")
3. Verify the other score options remain visible (grayed out) and can be clicked to change the selection

## 🖼️ Screenshots (if UI changes are included)

_No screenshot — unselected options now remain visible as they did before the regression._

## ✅ PR Checklist

- [x] Tested locally or on the dev environment
- [x] Code is clean, readable, and documented
- [ ] Tests added or updated (if needed)
- [x] Screenshots attached for UI changes (if any)
- [ ] Documentation updated (if relevant)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the desktop display behavior of the score level selector to ensure all selectable options remain visible to users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->