### PR TITLE
`Assessment`: Save button hidden when tutor evaluation is toggled off

### DIFF
--- a/clients/assessment_component/src/assessment/pages/SettingsPage/components/SchemaConfigurationCard.tsx
+++ b/clients/assessment_component/src/assessment/pages/SettingsPage/components/SchemaConfigurationCard.tsx
@@ -195,16 +195,14 @@ export const SchemaConfigurationCard = ({
 
       {isActive && children}
 
-      {isActive && (
-        <div className='flex flex-wrap items-center gap-3 border-t border-border pt-4'>
-          <p className='flex-1 text-xs leading-5 text-muted-foreground'>
-            Save this card to apply its configuration changes for the current course phase.
-          </p>
-          <Button onClick={onSave} disabled={saveDisabled} className='ml-auto min-w-[160px]'>
-            {isSaving ? 'Saving...' : `Save ${content.title}`}
-          </Button>
-        </div>
-      )}
+      <div className='flex flex-wrap items-center gap-3 border-t border-border pt-4'>
+        <p className='flex-1 text-xs leading-5 text-muted-foreground'>
+          Save this card to apply its configuration changes for the current course phase.
+        </p>
+        <Button onClick={onSave} disabled={saveDisabled} className='ml-auto min-w-[160px]'>
+          {isSaving ? 'Saving...' : `Save ${content.title}`}
+        </Button>
+      </div>
     </div>
   )
 


### PR DESCRIPTION
## ✨ What is the change?

Moves the Save button footer outside the `{isActive && ...}` guard in `SchemaConfigurationCard`. Previously the entire footer (including the Save button) was conditionally rendered only when the evaluation was active, so toggling tutor evaluation off caused the Save button to disappear.

## 📌 Reason for the change / Link to issue

Fixes #1517 — disabling tutor evaluation hid the Save button, making it impossible to persist the change. Reloading the page would revert the toggle back to enabled.

## 🧪 How to Test

1. Open an Assessment phase settings page with tutor evaluation enabled
2. Toggle "Tutor-evaluation enabled" to OFF
3. Verify the Save button remains visible
4. Click Save and reload — confirm the toggle stays OFF

## 🖼️ Screenshots (if UI changes are included)

| Before | After |
| --- | --- |
| Save button disappears when toggle is turned off | Save button remains visible |

## ✅ PR Checklist

- [ ] Tested locally or on the dev environment
- [ ] Code is clean, readable, and documented
- [ ] Tests added or updated (if needed)
- [ ] Screenshots attached for UI changes (if any)
- [ ] Documentation updated (if relevant)