### PR TITLE
`Documentation`: Improve README with filer startup in first Docker Compose run

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -124,10 +124,10 @@ cp .env.dev.template .env.dev  # Local development overrides
 
 The `.env` file contains Docker/production configuration. The `.env.dev` file contains local development overrides (localhost instead of Docker hostnames) and is loaded by `make server`.
 
-#### 3. Start Database & Keycloak
+#### 3. Start Database, Keycloak and File Storage
 
 ```bash
-docker compose up -d db keycloak
+docker compose up -d db keycloak seaweedfs-volume seaweedfs-s3
 ```
 
 #### 4. Configure Keycloak (first time only)
@@ -195,14 +195,19 @@ This launches all micro-frontends simultaneously using Lerna. The app runs at [h
 To start a specific micro-frontend only, navigate to its subdirectory and run `yarn run dev` there.
 
 ---
+
 ### Keycloak Passkey Testing
-#### Option 1 (Preconfigured user with passkey): 
-Log in as a user with credentials  username: student-passkey | password: student-passkey.
+
+#### Option 1 (Preconfigured user with passkey):
+
+Log in as a user with credentials username: student-passkey | password: student-passkey.
 You will be asked to register your passkey.
 With next login you can use your registered passkey instead of password-based authentication.
 
 #### Option 2 (Configure passkey manually):
+
 #### 1. Enable Registration for a User
+
 To test the flow, you must force a specific user to register their biometric data:
 
 Access Keycloak Admin: Go to http://localhost:8081 (Login: admin / admin).
@@ -220,6 +225,7 @@ Select "Webauthn Register Passwordless".
 Click "Save".
 
 #### 2. Register the Passkey
+
 Open http://localhost:3000 and click "Login".
 
 Sign in using standard credentials (e.g., student / student).
@@ -229,6 +235,7 @@ Keycloak will prompt you to register a passkey.
 Your browser/OS will prompt for user verification, such as Touch ID, Face ID, Windows Hello, a PIN, or a security key. Follow the prompts to complete registration.
 
 #### 3. Verify Passwordless Login
+
 Log out or open a new Incognito/Private window.
 
 Go to http://localhost:3000 → Login.


### PR DESCRIPTION
This PR improves the local setup documentation by including filer startup in the first Docker Compose run.

Without this, file storage services can be missed during initial setup, which may lead to confusion or incomplete local environments.

### What changed
- Updated `readme.md` Docker startup instructions
- Clarified first-run setup to include file storage/filer startup

Docs-only change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated setup instructions to include File Storage service configuration alongside Database and Keycloak.
  * Improved formatting and readability in Keycloak Passkey Testing documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->