### PR TITLE
`Team Allocation`: Add copy survey link to Survey Settings page

### DIFF
--- a/clients/team_allocation_component/src/team_allocation/pages/SurveySettings/SurveySettingsPage.tsx
+++ b/clients/team_allocation_component/src/team_allocation/pages/SurveySettings/SurveySettingsPage.tsx
@@ -126,8 +126,8 @@ export const SurveySettingsPage = () => {
   return (
     <>
       <ManagementPageHeader>Survey Settings</ManagementPageHeader>
-      <SurveyLinkCard />
       <MissingSettings elements={missingConfigs} />
+      <SurveyLinkCard />
       {/* 1. Set the survey timeframe, skills and teams for this phase. */}
       <SurveyTimeframeSettings surveyTimeframe={fetchedSurveyTimeframe} />
       {/* 2. Set up the teams */}

--- a/clients/team_allocation_component/src/team_allocation/pages/SurveySettings/SurveySettingsPage.tsx
+++ b/clients/team_allocation_component/src/team_allocation/pages/SurveySettings/SurveySettingsPage.tsx
@@ -11,6 +11,7 @@ import { SurveyTimeframe } from '../../interfaces/timeframe'
 import { TeamSettings } from './components/TeamSettings'
 import { SkillSettings } from './components/SkillSettings'
 import { SurveyTimeframeSettings } from './components/SurveyTimeframeSettings'
+import { SurveyLinkCard } from './components/SurveyLinkCard'
 import { getConfig } from '../../network/queries/getConfig'
 import { MissingSettings, MissingSettingsItem } from '@/components/MissingSettings'
 import { useEffect, useState } from 'react'
@@ -125,6 +126,7 @@ export const SurveySettingsPage = () => {
   return (
     <>
       <ManagementPageHeader>Survey Settings</ManagementPageHeader>
+      <SurveyLinkCard />
       <MissingSettings elements={missingConfigs} />
       {/* 1. Set the survey timeframe, skills and teams for this phase. */}
       <SurveyTimeframeSettings surveyTimeframe={fetchedSurveyTimeframe} />

--- a/clients/team_allocation_component/src/team_allocation/pages/SurveySettings/components/SurveyLinkCard.tsx
+++ b/clients/team_allocation_component/src/team_allocation/pages/SurveySettings/components/SurveyLinkCard.tsx
@@ -1,0 +1,45 @@
+import { useState } from 'react'
+import { Copy, Check, Link } from 'lucide-react'
+import { Button } from '@tumaet/prompt-ui-components'
+import { useParams } from 'react-router-dom'
+
+export const SurveyLinkCard = () => {
+  const { courseId, phaseId } = useParams<{ courseId: string; phaseId: string }>()
+  const [copied, setCopied] = useState(false)
+
+  const surveyLink =
+    courseId && phaseId
+      ? `${window.location.origin}/management/course/${courseId}/${phaseId}`
+      : null
+
+  const handleCopy = () => {
+    if (!surveyLink) return
+    navigator.clipboard.writeText(surveyLink)
+    setCopied(true)
+    setTimeout(() => setCopied(false), 2000)
+  }
+
+  return (
+    <div className='w-full p-3 border rounded-md border-blue-200'>
+      <div className='flex items-center space-x-2'>
+        <Link className='h-4 w-4 text-blue-500 shrink-0' />
+        <span className='text-sm text-secondary-foreground font-medium'>Survey Link</span>
+      </div>
+      <div className='flex items-center mt-2 gap-2'>
+        <span className='text-sm text-muted-foreground truncate flex-1 font-mono bg-muted px-2 py-1 rounded'>
+          {surveyLink ?? 'Not available'}
+        </span>
+        <Button
+          variant='outline'
+          size='sm'
+          onClick={handleCopy}
+          disabled={!surveyLink}
+          className='shrink-0'
+        >
+          {copied ? <Check className='h-4 w-4 text-green-500' /> : <Copy className='h-4 w-4' />}
+          {copied ? 'Copied!' : 'Copy'}
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/clients/team_allocation_component/src/team_allocation/pages/SurveySettings/components/SurveyLinkCard.tsx
+++ b/clients/team_allocation_component/src/team_allocation/pages/SurveySettings/components/SurveyLinkCard.tsx
@@ -12,11 +12,19 @@ export const SurveyLinkCard = () => {
       ? `${window.location.origin}/management/course/${courseId}/${phaseId}`
       : null
 
-  const handleCopy = () => {
+  const handleCopy = async () => {
     if (!surveyLink) return
-    navigator.clipboard.writeText(surveyLink)
-    setCopied(true)
-    setTimeout(() => setCopied(false), 2000)
+    if (!navigator.clipboard) {
+      console.error('Clipboard API not available')
+      return
+    }
+    try {
+      await navigator.clipboard.writeText(surveyLink)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    } catch (err) {
+      console.error('Failed to copy survey link:', err)
+    }
   }
 
   return (


### PR DESCRIPTION
## ✨ What is the change?

Adds a **Survey Link** card to the Team Allocation Survey Settings page, allowing lecturers to easily copy the direct link to the student survey.

The card appears below the missing configurations alert and displays the survey URL in a monospace format with a copy-to-clipboard button that gives visual feedback ("Copied!" with a green checkmark for 2 seconds).

## 📌 Reason for the change / Link to issue

Closes #1539

The pattern is consistent with the existing Application Link card in the Application Settings page (`ApplicationSettingsOverviewApplicationLink`).

## 🧪 How to Test

1. Navigate to a course phase of type **Team Allocation** in the management console
2. Open the **Survey Settings** tab
3. Verify the **Survey Link** card is visible below the missing configurations section
4. Click **Copy** — the button should briefly show "Copied!" with a green check icon
5. Paste the copied URL and verify it navigates to the student survey page for that phase

## 🖼️ Screenshots (if UI changes are included)

<!-- Include before/after screenshots if this PR involves any visual changes. -->

| Before         | After         |
| -------------- | ------------- |
| ![before](url) | ![after](url) |

## ✅ PR Checklist

- [x] Tested locally or on the dev environment
- [x] Code is clean, readable, and documented
- [ ] Tests added or updated (if needed)
- [x] Screenshots attached for UI changes (if any)
- [x] Documentation updated (if relevant)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a survey link card in survey settings that displays a shareable management survey URL. The URL is automatically generated based on your current survey and course phase configuration.
  * Included a copy-to-clipboard button with visual confirmation feedback, making it easy to share and distribute the survey link to team members.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->