### PR TITLE
`Application`: Fix for Useless assignment to field

### DIFF
--- a/servers/core/applicationAdministration/helper.go
+++ b/servers/core/applicationAdministration/helper.go
@@ -72,10 +72,10 @@ func addScoreName(oldMetaData meta.MetaData, newName, newKey string) ([]byte, er
 	}
 
 	keyExists := false
-	for _, item := range newScoreNamesArray {
-		if item.Key == newKey {
+	for i := range newScoreNamesArray {
+		if newScoreNamesArray[i].Key == newKey {
 			keyExists = true
-			item.Name = newName
+			newScoreNamesArray[i].Name = newName
 			break
 		}
 	}


### PR DESCRIPTION
To fix this without changing functionality, update the loop to modify the slice element in place (by index) instead of mutating the range value copy.

Best fix in this file:
- In `addScoreName` (around lines 75–80), replace `for _, item := range newScoreNamesArray` with an index-based loop `for i := range newScoreNamesArray`.
- Compare `newScoreNamesArray[i].Key` against `newKey`.
- Assign `newScoreNamesArray[i].Name = newName`.

No new imports, methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where score name updates were not being retained properly in application administration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->