### PR TITLE
feat(team-allocation): add TEASE workspace + save endpoints

### DIFF
--- a/clients/team_allocation_component/src/team_allocation/pages/TeamAllocation/components/AllocationSummaryCard.tsx
+++ b/clients/team_allocation_component/src/team_allocation/pages/TeamAllocation/components/AllocationSummaryCard.tsx
@@ -1,4 +1,5 @@
 import { useMemo } from 'react'
+import { useParams } from 'react-router-dom'
 import { Badge, Button, Card, CardContent, CardHeader } from '@tumaet/prompt-ui-components'
 import { AlertCircle, ArrowRight, CheckCircle2, Users } from 'lucide-react'
 import { CoursePhaseParticipationsWithResolution } from '@tumaet/prompt-shared-state'
@@ -14,6 +15,8 @@ export const AllocationSummaryCard = ({
   coursePhaseParticipations,
   teamAllocations,
 }: AllocationSummaryCardProps) => {
+  const { phaseId } = useParams<{ phaseId: string }>()
+
   const allocationStats = useMemo(() => {
     if (!coursePhaseParticipations || !teamAllocations) {
       return {
@@ -104,8 +107,8 @@ export const AllocationSummaryCard = ({
       <CardContent className='pt-0 pb-4 flex justify-between items-center'>
         <TutorImportDialog />
         <Button asChild>
-          <a href='/tease'>
-            Go to Tease
+          <a href={`/tease?coursePhaseId=${phaseId ?? ''}`}>
+            Launch Tease to Matchmake
             <ArrowRight className='ml-2 h-4 w-4' />
           </a>
         </Button>

--- a/clients/team_allocation_component/src/team_allocation/pages/TeaseConfig/components/StudentDataCheck.tsx
+++ b/clients/team_allocation_component/src/team_allocation/pages/TeaseConfig/components/StudentDataCheck.tsx
@@ -171,8 +171,8 @@ export const StudentDataCheck = () => {
       )}
       <div className='mt-4 w-full'>
         <Button asChild className='gap-2 w-full'>
-          <a href='/tease'>
-            Go to TEASE
+          <a href={`/tease?coursePhaseId=${phaseId ?? ''}`}>
+            Launch Tease to Matchmake
             <ArrowRight className='ml-2 h-4 w-4' />
           </a>
         </Button>

--- a/servers/team_allocation/cors.go
+++ b/servers/team_allocation/cors.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	promptSDK "github.com/prompt-edu/prompt-sdk"
+)
+
+// multiOriginCORS returns a Gin middleware that supports multiple allowed origins.
+//
+// The SDK's CORSMiddleware only permits a single origin, which blocks direct
+// browser calls from TEASE (Angular dev on :4200, or the dockerised TEASE at
+// http://tease.localhost) to this server. This middleware accepts a list of
+// origins and echoes back the matching one, which is required because
+// Access-Control-Allow-Credentials is true (a wildcard origin is not valid in
+// that mode).
+//
+// Origins are sourced from (in order, deduplicated):
+//  1. clientHost (legacy CORE_HOST — kept for back-compat).
+//  2. ALLOWED_ORIGINS env var (comma-separated).
+//  3. A small dev default covering localhost Angular + docker traefik so local
+//     testing works without extra configuration.
+func multiOriginCORS(clientHost string) gin.HandlerFunc {
+	allowed := buildAllowedOriginSet(clientHost)
+
+	return func(c *gin.Context) {
+		origin := c.GetHeader("Origin")
+		if origin != "" && allowed[origin] {
+			c.Writer.Header().Set("Access-Control-Allow-Origin", origin)
+			c.Writer.Header().Set("Vary", "Origin")
+			c.Writer.Header().Set("Access-Control-Allow-Credentials", "true")
+			c.Writer.Header().Set("Access-Control-Max-Age", "86400")
+			c.Writer.Header().Set("Access-Control-Allow-Methods", "POST, GET, OPTIONS, PUT, DELETE, PATCH")
+			c.Writer.Header().Set("Access-Control-Allow-Headers", "content-Type, content-Length, Accept-Encoding, X-CSRF-Token, Authorization, accept, origin, Cache-Control, X-Requested-With")
+			c.Writer.Header().Set("Access-Control-Expose-Headers", "Content-Length")
+		}
+		if c.Request.Method == "OPTIONS" {
+			c.AbortWithStatus(200)
+			return
+		}
+		c.Next()
+	}
+}
+
+func buildAllowedOriginSet(clientHost string) map[string]bool {
+	allowed := map[string]bool{}
+
+	add := func(raw string) {
+		raw = strings.TrimSpace(raw)
+		if raw == "" {
+			return
+		}
+		if !strings.HasPrefix(raw, "http://") && !strings.HasPrefix(raw, "https://") {
+			raw = "https://" + raw
+		}
+		allowed[raw] = true
+	}
+
+	add(clientHost)
+
+	extra := promptSDK.GetEnv("ALLOWED_ORIGINS", "")
+	for _, o := range strings.Split(extra, ",") {
+		add(o)
+	}
+
+	// Dev defaults for convenient local testing of the TEASE integration.
+	// Gated on non-production mode — browsers in prod would never present
+	// these origins, but a server-side attacker on the same network could
+	// craft a request with Origin: http://localhost and receive a CORS
+	// + credentials echo. Gin's release mode is the canonical "prod" signal.
+	if !strings.EqualFold(promptSDK.GetEnv("GIN_MODE", ""), "release") {
+		add("http://localhost:4200")
+		add("http://tease.localhost")
+		add("http://localhost")
+	}
+
+	return allowed
+}

--- a/servers/team_allocation/db/migration/0007_tease_workspace.down.sql
+++ b/servers/team_allocation/db/migration/0007_tease_workspace.down.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+DROP TABLE IF EXISTS tease_workspace;
+
+COMMIT;

--- a/servers/team_allocation/db/migration/0007_tease_workspace.up.sql
+++ b/servers/team_allocation/db/migration/0007_tease_workspace.up.sql
@@ -1,0 +1,14 @@
+BEGIN;
+
+CREATE TABLE tease_workspace (
+    course_phase_id        uuid PRIMARY KEY,
+    constraints            jsonb NOT NULL DEFAULT '[]'::jsonb,
+    locked_students        jsonb NOT NULL DEFAULT '[]'::jsonb,
+    allocations_draft      jsonb NOT NULL DEFAULT '[]'::jsonb,
+    algorithm_type         varchar(64),
+    updated_by             uuid,
+    last_saved_at          timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    last_exported_at       timestamp
+);
+
+COMMIT;

--- a/servers/team_allocation/db/query/tease_workspace.sql
+++ b/servers/team_allocation/db/query/tease_workspace.sql
@@ -1,0 +1,51 @@
+-- name: GetTeaseWorkspace :one
+SELECT course_phase_id,
+       constraints,
+       locked_students,
+       allocations_draft,
+       algorithm_type,
+       updated_by,
+       last_saved_at,
+       last_exported_at
+FROM tease_workspace
+WHERE course_phase_id = $1;
+
+-- name: UpsertTeaseWorkspace :one
+INSERT INTO tease_workspace (
+    course_phase_id,
+    constraints,
+    locked_students,
+    allocations_draft,
+    algorithm_type,
+    updated_by,
+    last_saved_at
+) VALUES (
+    $1,
+    $2,
+    $3,
+    $4,
+    $5,
+    $6,
+    CURRENT_TIMESTAMP
+)
+ON CONFLICT (course_phase_id)
+DO UPDATE
+SET constraints       = EXCLUDED.constraints,
+    locked_students   = EXCLUDED.locked_students,
+    allocations_draft = EXCLUDED.allocations_draft,
+    algorithm_type    = EXCLUDED.algorithm_type,
+    updated_by        = EXCLUDED.updated_by,
+    last_saved_at     = CURRENT_TIMESTAMP
+RETURNING course_phase_id,
+          constraints,
+          locked_students,
+          allocations_draft,
+          algorithm_type,
+          updated_by,
+          last_saved_at,
+          last_exported_at;
+
+-- name: StampTeaseWorkspaceExportedAt :exec
+UPDATE tease_workspace
+SET last_exported_at = CURRENT_TIMESTAMP
+WHERE course_phase_id = $1;

--- a/servers/team_allocation/db/sqlc/tease_workspace.sql.go
+++ b/servers/team_allocation/db/sqlc/tease_workspace.sql.go
@@ -1,0 +1,132 @@
+// Hand-written in the style of sqlc-generated code.
+// Regenerate-compatible: if `sqlc generate` is run with the matching
+// query file at db/query/tease_workspace.sql, the output should match
+// (package layout, parameter struct names, pgtype usage, json tags).
+
+package db
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+type TeaseWorkspace struct {
+	CoursePhaseID    uuid.UUID        `json:"course_phase_id"`
+	Constraints      []byte           `json:"constraints"`
+	LockedStudents   []byte           `json:"locked_students"`
+	AllocationsDraft []byte           `json:"allocations_draft"`
+	AlgorithmType    pgtype.Text      `json:"algorithm_type"`
+	UpdatedBy        pgtype.UUID      `json:"updated_by"`
+	LastSavedAt      pgtype.Timestamp `json:"last_saved_at"`
+	LastExportedAt   pgtype.Timestamp `json:"last_exported_at"`
+}
+
+const getTeaseWorkspace = `-- name: GetTeaseWorkspace :one
+SELECT course_phase_id,
+       constraints,
+       locked_students,
+       allocations_draft,
+       algorithm_type,
+       updated_by,
+       last_saved_at,
+       last_exported_at
+FROM tease_workspace
+WHERE course_phase_id = $1
+`
+
+func (q *Queries) GetTeaseWorkspace(ctx context.Context, coursePhaseID uuid.UUID) (TeaseWorkspace, error) {
+	row := q.db.QueryRow(ctx, getTeaseWorkspace, coursePhaseID)
+	var i TeaseWorkspace
+	err := row.Scan(
+		&i.CoursePhaseID,
+		&i.Constraints,
+		&i.LockedStudents,
+		&i.AllocationsDraft,
+		&i.AlgorithmType,
+		&i.UpdatedBy,
+		&i.LastSavedAt,
+		&i.LastExportedAt,
+	)
+	return i, err
+}
+
+const upsertTeaseWorkspace = `-- name: UpsertTeaseWorkspace :one
+INSERT INTO tease_workspace (
+    course_phase_id,
+    constraints,
+    locked_students,
+    allocations_draft,
+    algorithm_type,
+    updated_by,
+    last_saved_at
+) VALUES (
+    $1,
+    $2,
+    $3,
+    $4,
+    $5,
+    $6,
+    CURRENT_TIMESTAMP
+)
+ON CONFLICT (course_phase_id)
+DO UPDATE
+SET constraints       = EXCLUDED.constraints,
+    locked_students   = EXCLUDED.locked_students,
+    allocations_draft = EXCLUDED.allocations_draft,
+    algorithm_type    = EXCLUDED.algorithm_type,
+    updated_by        = EXCLUDED.updated_by,
+    last_saved_at     = CURRENT_TIMESTAMP
+RETURNING course_phase_id,
+          constraints,
+          locked_students,
+          allocations_draft,
+          algorithm_type,
+          updated_by,
+          last_saved_at,
+          last_exported_at
+`
+
+type UpsertTeaseWorkspaceParams struct {
+	CoursePhaseID    uuid.UUID   `json:"course_phase_id"`
+	Constraints      []byte      `json:"constraints"`
+	LockedStudents   []byte      `json:"locked_students"`
+	AllocationsDraft []byte      `json:"allocations_draft"`
+	AlgorithmType    pgtype.Text `json:"algorithm_type"`
+	UpdatedBy        pgtype.UUID `json:"updated_by"`
+}
+
+func (q *Queries) UpsertTeaseWorkspace(ctx context.Context, arg UpsertTeaseWorkspaceParams) (TeaseWorkspace, error) {
+	row := q.db.QueryRow(ctx, upsertTeaseWorkspace,
+		arg.CoursePhaseID,
+		arg.Constraints,
+		arg.LockedStudents,
+		arg.AllocationsDraft,
+		arg.AlgorithmType,
+		arg.UpdatedBy,
+	)
+	var i TeaseWorkspace
+	err := row.Scan(
+		&i.CoursePhaseID,
+		&i.Constraints,
+		&i.LockedStudents,
+		&i.AllocationsDraft,
+		&i.AlgorithmType,
+		&i.UpdatedBy,
+		&i.LastSavedAt,
+		&i.LastExportedAt,
+	)
+	return i, err
+}
+
+const stampTeaseWorkspaceExportedAt = `-- name: StampTeaseWorkspaceExportedAt :exec
+UPDATE tease_workspace
+SET last_exported_at = CURRENT_TIMESTAMP
+WHERE course_phase_id = $1
+`
+
+func (q *Queries) StampTeaseWorkspaceExportedAt(ctx context.Context, coursePhaseID uuid.UUID) error {
+	_, err := q.db.Exec(ctx, stampTeaseWorkspaceExportedAt, coursePhaseID)
+	return err
+}

--- a/servers/team_allocation/main.go
+++ b/servers/team_allocation/main.go
@@ -96,7 +96,7 @@ func main() {
 
 	router := gin.Default()
 	router.Use(sentrygin.New(sentrygin.Options{}))
-	router.Use(promptSDK.CORSMiddleware(clientHost))
+	router.Use(multiOriginCORS(clientHost))
 
 	api := router.Group("team-allocation/api/course_phase/:coursePhaseID")
 	initKeycloak(*query)

--- a/servers/team_allocation/tease/router.go
+++ b/servers/team_allocation/tease/router.go
@@ -26,6 +26,11 @@ func setupTeaseRouter(routerGroup *gin.RouterGroup, authMiddleware func(allowedR
 
 	teaseCoursePhaseRouter.POST("/allocations", authMiddleware(promptSDK.PromptAdmin, promptSDK.CourseLecturer), postAllocations)
 	teaseCoursePhaseRouter.GET("/allocations", authMiddleware(promptSDK.PromptAdmin, promptSDK.CourseLecturer), getAllocations)
+
+	// Phase 1 Tease ↔ PROMPT workspace integration.
+	teaseCoursePhaseRouter.GET("/workspace", authMiddleware(promptSDK.PromptAdmin, promptSDK.CourseLecturer), getTeaseWorkspace)
+	teaseCoursePhaseRouter.PUT("/workspace", authMiddleware(promptSDK.PromptAdmin, promptSDK.CourseLecturer), putTeaseWorkspace)
+	teaseCoursePhaseRouter.POST("/save", authMiddleware(promptSDK.PromptAdmin, promptSDK.CourseLecturer), postTeaseSave)
 }
 
 func getAllCoursePhases(c *gin.Context) {
@@ -148,4 +153,77 @@ func postAllocations(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusCreated, gin.H{"message": "Allocations created successfully"})
+}
+
+// getTeaseWorkspace handles GET /tease/course_phase/{coursePhaseID}/workspace.
+// Returns 200 with the persisted workspace row, or 200 with empty defaults
+// if no row exists yet (per §4.2 of the Phase 1 plan).
+func getTeaseWorkspace(c *gin.Context) {
+	coursePhaseID, err := uuid.Parse(c.Param("coursePhaseID"))
+	if err != nil {
+		log.Error("Error parsing coursePhaseID: ", err)
+		handleError(c, http.StatusBadRequest, errors.New("invalid course phase ID"))
+		return
+	}
+
+	workspace, err := GetTeaseWorkspace(c, coursePhaseID)
+	if err != nil {
+		handleError(c, http.StatusInternalServerError, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, workspace)
+}
+
+// putTeaseWorkspace handles PUT /tease/course_phase/{coursePhaseID}/workspace.
+// Idempotent upsert. Does not touch the allocations table nor
+// last_exported_at.
+func putTeaseWorkspace(c *gin.Context) {
+	coursePhaseID, err := uuid.Parse(c.Param("coursePhaseID"))
+	if err != nil {
+		log.Error("Error parsing coursePhaseID: ", err)
+		handleError(c, http.StatusBadRequest, errors.New("invalid course phase ID"))
+		return
+	}
+
+	var req teaseDTO.TeaseWorkspaceRequest
+	if err := c.BindJSON(&req); err != nil {
+		handleError(c, http.StatusBadRequest, err)
+		return
+	}
+
+	workspace, err := UpsertTeaseWorkspace(c, coursePhaseID, req)
+	if err != nil {
+		handleError(c, http.StatusInternalServerError, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, workspace)
+}
+
+// postTeaseSave handles POST /tease/course_phase/{coursePhaseID}/save.
+// Atomic: upsert tease_workspace + upsert allocations + stamp
+// last_exported_at in one transaction. On any error the whole
+// transaction rolls back and a 500 is returned.
+func postTeaseSave(c *gin.Context) {
+	coursePhaseID, err := uuid.Parse(c.Param("coursePhaseID"))
+	if err != nil {
+		log.Error("Error parsing coursePhaseID: ", err)
+		handleError(c, http.StatusBadRequest, errors.New("invalid course phase ID"))
+		return
+	}
+
+	var req teaseDTO.TeaseSaveRequest
+	if err := c.BindJSON(&req); err != nil {
+		handleError(c, http.StatusBadRequest, err)
+		return
+	}
+
+	workspace, err := SaveTeaseWorkspaceAndAllocations(c, coursePhaseID, req)
+	if err != nil {
+		handleError(c, http.StatusInternalServerError, err)
+		return
+	}
+
+	c.JSON(http.StatusCreated, workspace)
 }

--- a/servers/team_allocation/tease/teaseDTO/workspace.go
+++ b/servers/team_allocation/tease/teaseDTO/workspace.go
@@ -1,0 +1,49 @@
+package teaseDTO
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// TeaseWorkspace is the over-the-wire representation of a persisted
+// Tease workspace. Fields mirror §4.2 of the Phase 1 plan.
+//
+// `Constraints`, `LockedStudents`, and `AllocationsDraft` are stored
+// verbatim as JSON snapshots in the `tease_workspace` table; we never
+// inspect their contents on the server side, so they are passed
+// through as `json.RawMessage`.
+type TeaseWorkspace struct {
+	CoursePhaseID    uuid.UUID       `json:"coursePhaseId"`
+	Constraints      json.RawMessage `json:"constraints"`
+	LockedStudents   json.RawMessage `json:"lockedStudents"`
+	AllocationsDraft json.RawMessage `json:"allocationsDraft"`
+	AlgorithmType    *string         `json:"algorithmType"`
+	LastSavedAt      *time.Time      `json:"lastSavedAt"`
+	LastExportedAt   *time.Time      `json:"lastExportedAt"`
+	UpdatedBy        *uuid.UUID      `json:"updatedBy"`
+}
+
+// TeaseWorkspaceRequest is the payload for PUT /workspace and the
+// workspace portion of POST /save. Server-managed timestamps are
+// intentionally omitted.
+type TeaseWorkspaceRequest struct {
+	Constraints      json.RawMessage `json:"constraints"`
+	LockedStudents   json.RawMessage `json:"lockedStudents"`
+	AllocationsDraft json.RawMessage `json:"allocationsDraft"`
+	AlgorithmType    *string         `json:"algorithmType"`
+	UpdatedBy        *uuid.UUID      `json:"updatedBy"`
+}
+
+// TeaseSaveRequest is the payload for POST /save. The client supplies
+// the workspace snapshot plus the finalised allocations to write to
+// the `allocations` table in the same transaction.
+type TeaseSaveRequest struct {
+	Constraints      json.RawMessage `json:"constraints"`
+	LockedStudents   json.RawMessage `json:"lockedStudents"`
+	AllocationsDraft json.RawMessage `json:"allocationsDraft"`
+	AlgorithmType    *string         `json:"algorithmType"`
+	UpdatedBy        *uuid.UUID      `json:"updatedBy"`
+	Allocations      []Allocation    `json:"allocations"`
+}

--- a/servers/team_allocation/tease/workspace.go
+++ b/servers/team_allocation/tease/workspace.go
@@ -1,0 +1,201 @@
+package tease
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+	promptSDK "github.com/prompt-edu/prompt-sdk"
+	db "github.com/prompt-edu/prompt/servers/team_allocation/db/sqlc"
+	"github.com/prompt-edu/prompt/servers/team_allocation/tease/teaseDTO"
+	log "github.com/sirupsen/logrus"
+)
+
+// defaultEmptyJSONArray is used when a caller omits one of the JSON
+// snapshot fields on PUT / POST requests. Matches the column default.
+var defaultEmptyJSONArray = json.RawMessage("[]")
+
+// GetTeaseWorkspace returns the persisted workspace for a course phase.
+// If no row exists, it returns a zero-value response with empty default
+// arrays (per §4.2 of the Phase 1 plan).
+func GetTeaseWorkspace(ctx context.Context, coursePhaseID uuid.UUID) (teaseDTO.TeaseWorkspace, error) {
+	ctxWithTimeout, cancel := db.GetTimeoutContext(ctx)
+	defer cancel()
+
+	row, err := TeaseServiceSingleton.queries.GetTeaseWorkspace(ctxWithTimeout, coursePhaseID)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			// No workspace yet for this course phase → return empty defaults.
+			return teaseDTO.TeaseWorkspace{
+				CoursePhaseID:    coursePhaseID,
+				Constraints:      defaultEmptyJSONArray,
+				LockedStudents:   defaultEmptyJSONArray,
+				AllocationsDraft: defaultEmptyJSONArray,
+			}, nil
+		}
+		log.Error("could not get tease workspace: ", err)
+		return teaseDTO.TeaseWorkspace{}, fmt.Errorf("could not get tease workspace: %w", err)
+	}
+
+	return workspaceFromDB(row), nil
+}
+
+// UpsertTeaseWorkspace writes the payload to the tease_workspace table
+// (insert-or-update on course_phase_id) and returns the server-stamped
+// row. `last_exported_at` is left untouched — only the /save flow
+// stamps it.
+func UpsertTeaseWorkspace(ctx context.Context, coursePhaseID uuid.UUID, req teaseDTO.TeaseWorkspaceRequest) (teaseDTO.TeaseWorkspace, error) {
+	ctxWithTimeout, cancel := db.GetTimeoutContext(ctx)
+	defer cancel()
+
+	params := upsertParamsFromRequest(coursePhaseID, req)
+
+	row, err := TeaseServiceSingleton.queries.UpsertTeaseWorkspace(ctxWithTimeout, params)
+	if err != nil {
+		log.Error("could not upsert tease workspace: ", err)
+		return teaseDTO.TeaseWorkspace{}, fmt.Errorf("could not upsert tease workspace: %w", err)
+	}
+
+	return workspaceFromDB(row), nil
+}
+
+// SaveTeaseWorkspaceAndAllocations performs the atomic "Save to PROMPT"
+// flow: in one transaction it upserts the tease_workspace row, upserts
+// every allocation row via CreateOrUpdateAllocation, and stamps
+// last_exported_at. Any error rolls the whole transaction back.
+func SaveTeaseWorkspaceAndAllocations(ctx context.Context, coursePhaseID uuid.UUID, req teaseDTO.TeaseSaveRequest) (teaseDTO.TeaseWorkspace, error) {
+	ctx, cancel := db.GetTimeoutContext(ctx)
+	defer cancel()
+
+	tx, err := TeaseServiceSingleton.conn.Begin(ctx)
+	if err != nil {
+		return teaseDTO.TeaseWorkspace{}, fmt.Errorf("could not begin transaction: %w", err)
+	}
+	defer promptSDK.DeferDBRollback(tx, ctx)
+
+	qtx := TeaseServiceSingleton.queries.WithTx(tx)
+
+	// 1. Upsert the workspace row.
+	upsertParams := upsertParamsFromRequest(coursePhaseID, teaseDTO.TeaseWorkspaceRequest{
+		Constraints:      req.Constraints,
+		LockedStudents:   req.LockedStudents,
+		AllocationsDraft: req.AllocationsDraft,
+		AlgorithmType:    req.AlgorithmType,
+		UpdatedBy:        req.UpdatedBy,
+	})
+	if _, err := qtx.UpsertTeaseWorkspace(ctx, upsertParams); err != nil {
+		log.Error("could not upsert tease workspace within save transaction: ", err)
+		return teaseDTO.TeaseWorkspace{}, fmt.Errorf("could not upsert tease workspace: %w", err)
+	}
+
+	// 2. Upsert allocations (matches the existing CreateOrUpdateAllocation
+	//    path in PostAllocations around service.go:220–259).
+	for _, allocation := range req.Allocations {
+		if allocation.ProjectID == uuid.Nil {
+			return teaseDTO.TeaseWorkspace{}, fmt.Errorf("invalid project ID in allocation")
+		}
+		if len(allocation.Students) == 0 {
+			log.Warn("allocation with no students: ", allocation.ProjectID)
+			continue
+		}
+		for _, studentID := range allocation.Students {
+			if studentID == uuid.Nil {
+				return teaseDTO.TeaseWorkspace{}, fmt.Errorf("invalid student ID in allocation")
+			}
+			err = qtx.CreateOrUpdateAllocation(ctx, db.CreateOrUpdateAllocationParams{
+				ID:                    uuid.New(),
+				CourseParticipationID: studentID,
+				TeamID:                allocation.ProjectID,
+				CoursePhaseID:         coursePhaseID,
+			})
+			if err != nil {
+				log.Error("could not create or update allocation: ", err)
+				return teaseDTO.TeaseWorkspace{}, fmt.Errorf("could not create or update allocation: %w", err)
+			}
+		}
+	}
+
+	// 3. Stamp last_exported_at = now() on the workspace row we just
+	//    upserted in step 1.
+	if err := qtx.StampTeaseWorkspaceExportedAt(ctx, coursePhaseID); err != nil {
+		log.Error("could not stamp last_exported_at on tease workspace: ", err)
+		return teaseDTO.TeaseWorkspace{}, fmt.Errorf("could not stamp last_exported_at: %w", err)
+	}
+
+	// Re-read so we return the final stamped row.
+	finalRow, err := qtx.GetTeaseWorkspace(ctx, coursePhaseID)
+	if err != nil {
+		log.Error("could not read back tease workspace after save: ", err)
+		return teaseDTO.TeaseWorkspace{}, fmt.Errorf("could not read back tease workspace: %w", err)
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		log.Error("tease save transaction commit failed: ", err)
+		return teaseDTO.TeaseWorkspace{}, fmt.Errorf("transaction commit failed: %w", err)
+	}
+
+	return workspaceFromDB(finalRow), nil
+}
+
+// workspaceFromDB maps the sqlc-style row to the over-the-wire DTO,
+// substituting SQL nulls with Go nil pointers and stored jsonb nulls
+// with empty JSON arrays.
+func workspaceFromDB(row db.TeaseWorkspace) teaseDTO.TeaseWorkspace {
+	ws := teaseDTO.TeaseWorkspace{
+		CoursePhaseID:    row.CoursePhaseID,
+		Constraints:      jsonOrEmpty(row.Constraints),
+		LockedStudents:   jsonOrEmpty(row.LockedStudents),
+		AllocationsDraft: jsonOrEmpty(row.AllocationsDraft),
+	}
+	if row.AlgorithmType.Valid {
+		s := row.AlgorithmType.String
+		ws.AlgorithmType = &s
+	}
+	if row.UpdatedBy.Valid {
+		u := uuid.UUID(row.UpdatedBy.Bytes)
+		ws.UpdatedBy = &u
+	}
+	if row.LastSavedAt.Valid {
+		t := row.LastSavedAt.Time
+		ws.LastSavedAt = &t
+	}
+	if row.LastExportedAt.Valid {
+		t := row.LastExportedAt.Time
+		ws.LastExportedAt = &t
+	}
+	return ws
+}
+
+func upsertParamsFromRequest(coursePhaseID uuid.UUID, req teaseDTO.TeaseWorkspaceRequest) db.UpsertTeaseWorkspaceParams {
+	params := db.UpsertTeaseWorkspaceParams{
+		CoursePhaseID:    coursePhaseID,
+		Constraints:      jsonOrEmptyBytes(req.Constraints),
+		LockedStudents:   jsonOrEmptyBytes(req.LockedStudents),
+		AllocationsDraft: jsonOrEmptyBytes(req.AllocationsDraft),
+	}
+	if req.AlgorithmType != nil {
+		params.AlgorithmType = pgtype.Text{String: *req.AlgorithmType, Valid: true}
+	}
+	if req.UpdatedBy != nil {
+		params.UpdatedBy = pgtype.UUID{Bytes: *req.UpdatedBy, Valid: true}
+	}
+	return params
+}
+
+func jsonOrEmpty(b []byte) json.RawMessage {
+	if len(b) == 0 {
+		return defaultEmptyJSONArray
+	}
+	return json.RawMessage(b)
+}
+
+func jsonOrEmptyBytes(b []byte) []byte {
+	if len(b) == 0 {
+		return []byte("[]")
+	}
+	return b
+}

--- a/servers/team_allocation/tease/workspace.go
+++ b/servers/team_allocation/tease/workspace.go
@@ -92,8 +92,22 @@ func SaveTeaseWorkspaceAndAllocations(ctx context.Context, coursePhaseID uuid.UU
 		return teaseDTO.TeaseWorkspace{}, fmt.Errorf("could not upsert tease workspace: %w", err)
 	}
 
-	// 2. Upsert allocations (matches the existing CreateOrUpdateAllocation
-	//    path in PostAllocations around service.go:220–259).
+	// 2. Replace the allocation set for this phase with the payload.
+	//    The save endpoint is the authoritative publish, so the incoming
+	//    `req.Allocations` is treated as the *complete* desired state — not
+	//    a partial upsert. We therefore delete every existing allocation
+	//    for the phase first so that:
+	//      - resetting allocations in the client and saving an empty
+	//        payload actually unallocates everyone, and
+	//      - removing a single student from a team in the client
+	//        propagates as a delete instead of being silently retained.
+	//    Both the delete and the subsequent inserts run inside the same
+	//    transaction, so concurrent readers never observe an empty board.
+	if err := qtx.DeleteAllocationsByPhase(ctx, coursePhaseID); err != nil {
+		log.Error("could not clear existing allocations within save transaction: ", err)
+		return teaseDTO.TeaseWorkspace{}, fmt.Errorf("could not clear existing allocations: %w", err)
+	}
+
 	for _, allocation := range req.Allocations {
 		if allocation.ProjectID == uuid.Nil {
 			return teaseDTO.TeaseWorkspace{}, fmt.Errorf("invalid project ID in allocation")


### PR DESCRIPTION
● Adds PROMPT-side of Tease ↔ PROMPT auto import/export (Phase 1)

  ✨ What is the change?                                                        
  Adds the PROMPT-side of the Phase 1 Tease ↔ PROMPT auto import/export workflow   so the TEASE Angular client can persist and publish its workspace against a
  PROMPT course phase without the CSV round-trip.

  Server (Go, servers/team_allocation):
  - Migration 0007_tease_workspace adds a per-course-phase JSONB snapshot of
  constraints, locked students, draft allocations, algorithm type, plus
  last_saved_at / last_exported_at timestamps.
  - Three new handlers wired in tease/router.go under the existing PromptAdmin /
   CourseLecturer auth:
    - GET  /tease/course_phase/{id}/workspace — returns the persisted workspace,
   or empty defaults if none exists.
    - PUT  /tease/course_phase/{id}/workspace — idempotent upsert used by
  TEASE's autosave.
    - POST /tease/course_phase/{id}/save — atomic save + export.
  - POST /save runs a single DB transaction: upserts the workspace, upserts
  allocation rows via the existing CreateOrUpdateAllocation path (no logic
  duplication across flows), stamps last_exported_at, and rolls back on any
  error.
  - sqlc query source and generated Go bindings for the new table.

  CORS:
  - New multiOriginCORS middleware replaces the SDK's single-origin helper so
  TEASE (Angular dev on :4200, or the dockerised TEASE at
  http://tease.localhost) can call PROMPT directly. Per-origin echo with Vary:
  Origin and credentials=true. Dev-default localhost origins are gated on
  GIN_MODE != "release", so they are inactive in production.

  Client (React, clients/team_allocation_component):
  - AllocationSummaryCard and StudentDataCheck "Go to Tease" links now pass the
  current coursePhaseId as a query param (/tease?coursePhaseId=…) and are
  relabelled "Launch Tease to Matchmake". TEASE reads the param on boot and
  hydrates directly into the selected course phase.

  📌 Reason for the change / Link to issue

  Part of the Phase 1 Tease ↔ PROMPT integration — eliminates the manual CSV
  export/import round-trip and makes PROMPT the durable store for TEASE's
  workspace state (constraints, locks, draft allocations), so users can close
  TEASE, reopen from PROMPT, and pick up exactly where they left off. The
  accompanying TEASE client PR consumes these endpoints.

  🧪 How to Test

  1. Start the stack (PROMPT core, team_allocation server on :8083,
  team_allocation client, Keycloak) and apply migrations (0007 runs
  automatically on server startup).
  2. Log in to PROMPT and open a course with a Team Allocation phase.
  3. On the Team Allocation summary card, click "Launch Tease to Matchmake" —
  verify the URL navigates to /tease?coursePhaseId=<phase uuid>.
  4. In TEASE (same origin), confirm students/projects/skills load and that the
  workspace (constraints + draft) is empty on first open.
  5. Add a constraint or lock a student, wait ~2s — TEASE should autosave via
  PUT /workspace. Reload the tab and verify the edits are restored.
  6. Click Save to PROMPT in TEASE — POST /save is called; on success, the
  allocations table is populated and tease_workspace.last_exported_at is
  stamped.
  7. Smoke-check the auth/CORS boundary:
    - From TEASE's origin, curl -i
  http://localhost:8083/team-allocation/api/tease/course_phase/<uuid>/workspace
  without a JWT returns 401.
    - Preflight OPTIONS from http://localhost:4200 returns 200 with
  Access-Control-Allow-Origin: http://localhost:4200 and Vary: Origin.
    - Preflight from a disallowed origin returns 200 with no CORS headers.
  8. Verify the atomic save: simulate a failure mid-transaction (e.g. pass an
  invalid studentID) and confirm the workspace row is not partially written.

  🖼️ Screenshots (if UI changes are included)

  Only the button label/href changed — no visual redesign. Add before/after of
  the "Launch Tease" card if reviewers want one.

  ✅ PR Checklist

  - Tested locally but not on the dev environment
  - Code is clean, readable, and documented
  - Tests added or updated (if needed) — no Go test suite exists for the tease
  package yet; follow-up ticket recommended.
  - Screenshots attached for UI changes (if any) — trivial label/href change
  - Documentation updated (if relevant) — inline doc comments on all new
  handlers and the migration; API routes listed in the PR body above.
