### PR TITLE
`Core`: Fix course template and archive paths

### DIFF
--- a/clients/core/src/managementConsole/layout/Breadcrumbs/Breadcrumbs.tsx
+++ b/clients/core/src/managementConsole/layout/Breadcrumbs/Breadcrumbs.tsx
@@ -41,10 +41,10 @@ export const Breadcrumbs: React.FC = () => {
             path: `/management/courses/${pathSegments.slice(2, index + 3).join('/')}`,
           })
         })
-      } else if (pathSegments[1] === 'course_templates') {
-        breadcrumbs.push({ title: 'Template Courses', path: '/management/course_templates' })
-      } else if (pathSegments[1] === 'course_archive') {
-        breadcrumbs.push({ title: 'Archived Courses', path: '/management/course_archive' })
+      } else if (pathSegments[1] === 'course-templates') {
+        breadcrumbs.push({ title: 'Template Courses', path: '/management/course-templates' })
+      } else if (pathSegments[1] === 'course-archive') {
+        breadcrumbs.push({ title: 'Archived Courses', path: '/management/course-archive' })
       } else if (pathSegments[1] === 'privacy') {
         breadcrumbs.push({ title: 'Privacy', path: '/management/privacy' })
         if (pathSegments[2] === 'data-export') {

--- a/clients/core/src/managementConsole/layout/Sidebar/InsideSidebar/InsideGeneralSidebar.tsx
+++ b/clients/core/src/managementConsole/layout/Sidebar/InsideSidebar/InsideGeneralSidebar.tsx
@@ -19,14 +19,14 @@ export const InsideGeneralSidebar = () => {
             <ShowForRole roles={[Role.PROMPT_LECTURER, Role.PROMPT_ADMIN]}>
               <InsideSidebarMenuItem
                 icon={<File />}
-                goToPath={'/management/course_templates'}
+                goToPath={'/management/course-templates'}
                 title='Template Courses'
               />
             </ShowForRole>
             <ShowForRole roles={[Role.PROMPT_LECTURER, Role.PROMPT_ADMIN]}>
               <InsideSidebarMenuItem
                 icon={<Archive />}
-                goToPath={'/management/course_archive'}
+                goToPath={'/management/course-archive'}
                 title='Archived Courses'
               />
             </ShowForRole>


### PR DESCRIPTION
# 📝 Pull Request Template

Use this template to provide all necessary information for reviewing and testing your changes.

## ✨ What is the change?

This PR updates the routing paths for course templates and archived courses in both the `Breadcrumbs` and `InsideGeneralSidebar` components. It changes the path segments from using underscores (`course_templates`, `course_archive`) to hyphens (`course-templates`, `course-archive`).

## 📌 Reason for the change / Link to issue

To ensure consistency in URL routing and properly resolve breadcrumb and sidebar highlights for template and archived courses, aligning them with the actual router configuration format.

## 🧪 How to Test

1. Navigate to the management console.
2. Click on "Template Courses" in the sidebar.
3. Verify that the URL updates to `/management/course-templates`.
4. Verify that the breadcrumbs correctly display "Template Courses".
5. Repeat the process for "Archived Courses" and verify the path is `/management/course-archive`.

## 🖼️ Screenshots (if UI changes are included)

<!-- Include before/after screenshots if this PR involves any visual changes. -->

| Before         | After         |
| -------------- | ------------- |
| ![before](url) | ![after](url) |

## ✅ PR Checklist

- [x] Tested locally or on the dev environment
- [x] Code is clean, readable, and documented
- [ ] Tests added or updated (if needed)
- [ ] Screenshots attached for UI changes (if any)
- [ ] Documentation updated (if relevant)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated navigation routes for course templates and archived courses to use consistent URL formatting across breadcrumb navigation and sidebar menu links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->