### PR TITLE
`Core`: Remove role check for privacy page

### DIFF
--- a/clients/core/src/App.tsx
+++ b/clients/core/src/App.tsx
@@ -133,17 +133,7 @@ export const App = () => {
               path='/management/privacy'
               element={
                 <ManagementRoot>
-                  <PermissionRestriction
-                    requiredPermissions={[
-                      Role.PROMPT_ADMIN,
-                      Role.PROMPT_LECTURER,
-                      Role.COURSE_STUDENT,
-                      Role.COURSE_LECTURER,
-                      Role.COURSE_EDITOR,
-                    ]}
-                  >
-                    <PrivacyOverviewPage />
-                  </PermissionRestriction>
+                  <PrivacyOverviewPage />
                 </ManagementRoot>
               }
             />

--- a/clients/core/src/App.tsx
+++ b/clients/core/src/App.tsx
@@ -141,17 +141,7 @@ export const App = () => {
               path='/management/privacy/data-export'
               element={
                 <ManagementRoot>
-                  <PermissionRestriction
-                    requiredPermissions={[
-                      Role.PROMPT_ADMIN,
-                      Role.PROMPT_LECTURER,
-                      Role.COURSE_STUDENT,
-                      Role.COURSE_LECTURER,
-                      Role.COURSE_EDITOR,
-                    ]}
-                  >
-                    <PrivacyDataExportPage />
-                  </PermissionRestriction>
+                  <PrivacyDataExportPage />
                 </ManagementRoot>
               }
             />
@@ -159,17 +149,7 @@ export const App = () => {
               path='/management/privacy/data-deletion'
               element={
                 <ManagementRoot>
-                  <PermissionRestriction
-                    requiredPermissions={[
-                      Role.PROMPT_ADMIN,
-                      Role.PROMPT_LECTURER,
-                      Role.COURSE_STUDENT,
-                      Role.COURSE_LECTURER,
-                      Role.COURSE_EDITOR,
-                    ]}
-                  >
-                    <PrivacyDataDeletionPage />
-                  </PermissionRestriction>
+                  <PrivacyDataDeletionPage />
                 </ManagementRoot>
               }
             />


### PR DESCRIPTION
## ✨ What is the change?

- This pull request removes the role check for the privacy page.

This makes sense anyways because: 
1) any user should be able to open the privacy page 
2) the previous roll check wouldn't work anyways because the roles COURSE_... only work on routes that contain the courseID in the path

## 📌 Reason for the change / Link to issue

fixes #1562 

## 🧪 How to Test

1. log in as a student user (doesn't matter whether assigned to courses or not, but preferrably test both)
2. open the privacy page by clicking on your profile and then on Privacy.

## 🖼️ Screenshots (if UI changes are included)

no UI changes

## ✅ PR Checklist

- [x] Tested locally or on the dev environment
- [x] Code is clean, readable, and documented
- [] Tests added or updated (if needed)
- [] Screenshots attached for UI changes (if any)
- [] Documentation updated (if relevant)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Features**
  * Privacy management pages (data export and deletion) are now more broadly accessible within the management section.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/prompt-edu/prompt/pull/1622)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->