### PR TITLE
Core: Update privacy policy - replace Art. 6(1)(f) GDPR with public task basis and simplify retention periods

### DIFF
--- a/clients/core/public/privacy.html
+++ b/clients/core/public/privacy.html
@@ -79,10 +79,6 @@
         <strong>Art. 6 Abs. 1 lit. a DSGVO:</strong>
         Einwilligung, soweit Sie uns für bestimmte Verarbeitungen eine ausdrückliche Einwilligung erteilt haben (z.&nbsp;B. Profilbilder über Gravatar, freiwillige Angaben im Bewerbungsformular).
       </li>
-      <li>
-        <strong>Art. 6 Abs. 1 lit. f DSGVO:</strong>
-        Berechtigtes Interesse an der Sicherstellung des ordnungsgemäßen Betriebs und der IT-Sicherheit der Plattform. Dies umfasst die Verarbeitung von Serverprotokollen und Systemmetriken sowie deren automatisierte Analyse, einschließlich des Einsatzes KI-gestützter Anomalieerkennungssysteme zum Schutz der IT-Infrastruktur (vgl. Abschnitt 5.11). Das berechtigte Interesse ergibt sich aus der Notwendigkeit, die Verfügbarkeit, Integrität und Vertraulichkeit der Plattform und der darin verarbeiteten Daten zu gewährleisten.
-      </li>
     </ul>
   </section>
 
@@ -222,7 +218,7 @@
     <!-- 5.11 -->
     <h3 class="text-lg font-semibold mt-4 mb-2">5.11 Serverprotokolle und Systemmetriken</h3>
     <p><strong>Zweck:</strong> Sicherstellung des ordnungsgemäßen Betriebs, Erkennung und Abwehr von Angriffen, Fehlerbehebung, Verfügbarkeitsüberwachung, Kapazitätsplanung</p>
-    <p><strong>Rechtsgrundlage:</strong> Art. 6 Abs. 1 lit. f DSGVO (berechtigtes Interesse an der IT-Sicherheit und Betriebsfähigkeit der Plattform)</p>
+    <p><strong>Rechtsgrundlage:</strong> Art. 6 Abs. 1 lit. e DSGVO i.V.m. Art. 4 Abs. 1 BayDSG und Art. 2 Abs. 1 BayHIG</p>
 
     <p class="mt-2"><strong>5.11.1 Serverprotokolle (Logdaten)</strong></p>
     <p class="mt-1">Bei jedem Zugriff auf die Plattform werden folgende Daten in Protokolldateien verarbeitet:</p>
@@ -246,7 +242,7 @@
       <li>Dienstverfügbarkeit und Neustartinformationen</li>
     </ul>
     <p class="mt-1">
-      Diese Systemmetriken sind technische Betriebsdaten und enthalten grundsätzlich keine personenbezogenen Daten. Soweit durch die Kombination mit Protokolldaten (insbesondere IP-Adressen) ein Personenbezug hergestellt werden könnte, erfolgt die Verarbeitung auf Grundlage von Art. 6 Abs. 1 lit. f DSGVO.
+      Diese Systemmetriken sind technische Betriebsdaten und enthalten grundsätzlich keine personenbezogenen Daten. Soweit durch die Kombination mit Protokolldaten (insbesondere IP-Adressen) ein Personenbezug hergestellt werden könnte, erfolgt die Verarbeitung auf Grundlage von Art. 6 Abs. 1 lit. e DSGVO i.V.m. Art. 4 Abs. 1 BayDSG und Art. 2 Abs. 1 BayHIG.
     </p>
 
     <p class="mt-2"><strong>5.11.3 Automatisierte Analyse und KI-gestützte Erkennung</strong></p>
@@ -276,13 +272,13 @@
 
     <h3 class="text-lg font-semibold mt-4 mb-2">6.1 Gravatar (Automattic Inc., USA)</h3>
     <p>
-      Zur Anzeige von Profilbildern wird der Dienst Gravatar der Automattic Inc. (60 29th Street #343, San Francisco, CA 94110, USA) genutzt. Dabei wird ein SHA-256-Hash Ihrer E-Mail-Adresse an die Server von Automattic in den USA übermittelt, um ein ggf. hinterlegtes Profilbild abzurufen. Die Übermittlung erfolgt auf Grundlage von Art. 6 Abs. 1 lit. f DSGVO (berechtigtes Interesse an einer personalisierten Nutzererfahrung). Automattic nimmt am EU-U.S. Data Privacy Framework teil. Weitere Informationen finden Sie unter:
+      Zur Anzeige von Profilbildern wird der Dienst Gravatar der Automattic Inc. (60 29th Street #343, San Francisco, CA 94110, USA) genutzt. Dabei wird ein SHA-256-Hash Ihrer E-Mail-Adresse an die Server von Automattic in den USA übermittelt, um ein ggf. hinterlegtes Profilbild abzurufen. Die Übermittlung erfolgt auf Grundlage von Art. 6 Abs. 1 lit. e DSGVO i.V.m. Art. 4 Abs. 1 BayDSG und Art. 2 Abs. 1 BayHIG. Automattic nimmt am EU-U.S. Data Privacy Framework teil. Weitere Informationen finden Sie unter:
       <a href="https://automattic.com/privacy/" target="_blank" rel="noopener noreferrer">https://automattic.com/privacy/</a>.
     </p>
 
     <h3 class="text-lg font-semibold mt-4 mb-2">6.2 GitHub (Microsoft Corporation, USA)</h3>
     <p>
-      Auf der „Über"-Seite der Plattform werden Beitragslisten über die GitHub-API (Microsoft Corporation, One Microsoft Way, Redmond, WA 98052, USA) abgerufen. Dabei wird Ihre IP-Adresse an die Server von GitHub übermittelt. Es werden keine personenbezogenen Daten aus Ihrem PROMPT-Konto an GitHub weitergegeben. Die Übermittlung erfolgt auf Grundlage von Art. 6 Abs. 1 lit. f DSGVO (berechtigtes Interesse an der Darstellung der Projektmitarbeitenden). Microsoft nimmt am EU-U.S. Data Privacy Framework teil. Weitere Informationen finden Sie unter:
+      Auf der „Über"-Seite der Plattform werden Beitragslisten über die GitHub-API (Microsoft Corporation, One Microsoft Way, Redmond, WA 98052, USA) abgerufen. Dabei wird Ihre IP-Adresse an die Server von GitHub übermittelt. Es werden keine personenbezogenen Daten aus Ihrem PROMPT-Konto an GitHub weitergegeben. Die Übermittlung erfolgt auf Grundlage von Art. 6 Abs. 1 lit. e DSGVO i.V.m. Art. 4 Abs. 1 BayDSG und Art. 2 Abs. 1 BayHIG. Microsoft nimmt am EU-U.S. Data Privacy Framework teil. Weitere Informationen finden Sie unter:
       <a href="https://docs.github.com/en/site-policy/privacy-policies/github-general-privacy-statement" target="_blank" rel="noopener noreferrer">GitHub Privacy Statement</a>.
     </p>
 
@@ -305,45 +301,14 @@
     </p>
     <ul class="list-disc pl-6 space-y-2 mt-2">
       <li>
-        <strong>Bewertungs- und Leistungsdaten (prüfungsrelevant):</strong>
-        Diese Daten werden gemäß den geltenden Prüfungsordnungen (APSO der TUM) aufbewahrt. Die Aufbewahrungsfrist für Prüfungsunterlagen beträgt gemäß den einschlägigen bayerischen Regelungen mindestens zwei Jahre nach Bekanntgabe des Prüfungsergebnisses (§ 12 RaPO). Prüfungsbezogene Stammdaten (reduzierte Prüfungsakte) können bis zu 50 Jahre aufbewahrt werden.
-      </li>
-      <li>
-        <strong>Bewerbungsdaten:</strong>
-        Werden nach Abschluss des Auswahlverfahrens gelöscht, es sei denn, der Bewerber wird als Kursteilnehmer angenommen; in diesem Fall werden die Daten für die Dauer der Kursteilnahme aufbewahrt.
-      </li>
-      <li>
-        <strong>Interviewdaten:</strong>
-        Werden nach Abschluss des Auswahlverfahrens gelöscht.
-      </li>
-      <li>
-        <strong>Teamzuordnungsdaten:</strong>
-        Werden nach Ende der Lehrveranstaltung gelöscht.
-      </li>
-      <li>
-        <strong>Entwicklerprofile:</strong>
-        Werden nach Ende der Lehrveranstaltung gelöscht.
-      </li>
-      <li>
-        <strong>Zertifikatsdaten:</strong>
-        Werden aufbewahrt, solange ein berechtigtes Interesse der Studierenden am erneuten Abruf besteht.
+        <strong>Kursbezogene Daten (Bewerbungs-, Interview-, Teamzuordnungs-, Bewertungs-, Zertifikats- und Entwicklerprofildaten):</strong>
+        Diese Daten werden fünf Jahre nach Ende der letzten Lehrveranstaltung, an der die betroffene Person auf der Plattform teilgenommen hat, gelöscht.
       </li>
       <li>
         <strong>Serverprotokolle:</strong>
         Werden nach spätestens 30 Tagen gelöscht.
       </li>
-      <li>
-        <strong>Systemmetriken:</strong>
-        Aggregierte Systemmetriken (ohne Personenbezug) können zu Zwecken der Kapazitätsplanung und Trendanalyse länger aufbewahrt werden. Soweit Metriken einen Personenbezug aufweisen könnten (z.&nbsp;B. durch Verknüpfung mit IP-Adressen), werden sie nach spätestens 30 Tagen gelöscht oder anonymisiert.
-      </li>
-      <li>
-        <strong>Authentifizierungsdaten:</strong>
-        Sitzungsdaten verfallen automatisch nach maximal 24 Stunden. Kontodaten im Identity Provider werden gelöscht, wenn das Konto nicht mehr benötigt wird.
-      </li>
     </ul>
-    <p class="mt-2">
-      Bei der Archivierung einer Lehrveranstaltung werden die zugehörigen Daten als inaktiv markiert. Die endgültige Löschung erfolgt gemäß den oben genannten Fristen.
-    </p>
   </section>
 
   <!-- Section 8: Lokale Speicherung im Browser -->
@@ -539,10 +504,6 @@
         <strong>Art. 6(1)(a) GDPR:</strong>
         Consent, where you have given explicit consent for specific processing activities (e.g. profile pictures via Gravatar, voluntary information in application forms).
       </li>
-      <li>
-        <strong>Art. 6(1)(f) GDPR:</strong>
-        Legitimate interest in ensuring the proper operation and IT security of the platform. This includes the processing of server logs and system metrics as well as their automated analysis, including the use of AI-based anomaly detection systems to protect the IT infrastructure (see Section 5.11). The legitimate interest arises from the necessity to ensure the availability, integrity, and confidentiality of the platform and the data processed therein.
-      </li>
     </ul>
   </section>
 
@@ -682,7 +643,7 @@
     <!-- 5.11 -->
     <h3 class="text-lg font-semibold mt-4 mb-2">5.11 Server Logs and System Metrics</h3>
     <p><strong>Purpose:</strong> Ensuring proper operation, detection and prevention of attacks, error resolution, availability monitoring, capacity planning</p>
-    <p><strong>Legal basis:</strong> Art. 6(1)(f) GDPR (legitimate interest in IT security and operational stability of the platform)</p>
+    <p><strong>Legal basis:</strong> Art. 6(1)(e) GDPR in conjunction with Art. 4(1) BayDSG and Art. 2(1) BayHIG</p>
 
     <p class="mt-2"><strong>5.11.1 Server Logs</strong></p>
     <p class="mt-1">Each time the platform is accessed, the following data is processed in log files:</p>
@@ -706,7 +667,7 @@
       <li>Service availability and restart information</li>
     </ul>
     <p class="mt-1">
-      These system metrics are technical operational data and generally do not contain personal data. Where a personal reference could be established through combination with log data (in particular IP addresses), processing is based on Art. 6(1)(f) GDPR.
+      These system metrics are technical operational data and generally do not contain personal data. Where a personal reference could be established through combination with log data (in particular IP addresses), processing is based on Art. 6(1)(e) GDPR in conjunction with Art. 4(1) BayDSG and Art. 2(1) BayHIG.
     </p>
 
     <p class="mt-2"><strong>5.11.3 Automated Analysis and AI-Based Detection</strong></p>
@@ -736,13 +697,13 @@
 
     <h3 class="text-lg font-semibold mt-4 mb-2">6.1 Gravatar (Automattic Inc., USA)</h3>
     <p>
-      To display profile pictures, the service Gravatar by Automattic Inc. (60 29th Street #343, San Francisco, CA 94110, USA) is used. A SHA-256 hash of your email address is transmitted to Automattic's servers in the USA to retrieve a profile picture, if one has been configured. The transfer is based on Art. 6(1)(f) GDPR (legitimate interest in a personalised user experience). Automattic participates in the EU-U.S. Data Privacy Framework. More information:
+      To display profile pictures, the service Gravatar by Automattic Inc. (60 29th Street #343, San Francisco, CA 94110, USA) is used. A SHA-256 hash of your email address is transmitted to Automattic's servers in the USA to retrieve a profile picture, if one has been configured. The transfer is based on Art. 6(1)(e) GDPR in conjunction with Art. 4(1) BayDSG and Art. 2(1) BayHIG. Automattic participates in the EU-U.S. Data Privacy Framework. More information:
       <a href="https://automattic.com/privacy/" target="_blank" rel="noopener noreferrer">https://automattic.com/privacy/</a>.
     </p>
 
     <h3 class="text-lg font-semibold mt-4 mb-2">6.2 GitHub (Microsoft Corporation, USA)</h3>
     <p>
-      On the "About" page of the platform, contributor lists are retrieved via the GitHub API (Microsoft Corporation, One Microsoft Way, Redmond, WA 98052, USA). Your IP address is transmitted to GitHub's servers in this process. No personal data from your PROMPT account is shared with GitHub. The transfer is based on Art. 6(1)(f) GDPR (legitimate interest in displaying project contributors). Microsoft participates in the EU-U.S. Data Privacy Framework. More information:
+      On the "About" page of the platform, contributor lists are retrieved via the GitHub API (Microsoft Corporation, One Microsoft Way, Redmond, WA 98052, USA). Your IP address is transmitted to GitHub's servers in this process. No personal data from your PROMPT account is shared with GitHub. The transfer is based on Art. 6(1)(e) GDPR in conjunction with Art. 4(1) BayDSG and Art. 2(1) BayHIG. Microsoft participates in the EU-U.S. Data Privacy Framework. More information:
       <a href="https://docs.github.com/en/site-policy/privacy-policies/github-general-privacy-statement" target="_blank" rel="noopener noreferrer">GitHub Privacy Statement</a>.
     </p>
 
@@ -765,45 +726,14 @@
     </p>
     <ul class="list-disc pl-6 space-y-2 mt-2">
       <li>
-        <strong>Assessment and performance data (examination-relevant):</strong>
-        Retained in accordance with the applicable examination regulations (APSO of TUM). Under the applicable Bavarian regulations, examination documents must be retained for at least two years after notification of the examination result (Section 12 RaPO). Examination-related master data (reduced examination file) may be retained for up to 50 years.
-      </li>
-      <li>
-        <strong>Application data:</strong>
-        Deleted after the selection process concludes, unless the applicant is accepted as a course participant, in which case data is retained for the duration of the course.
-      </li>
-      <li>
-        <strong>Interview data:</strong>
-        Deleted after the selection process concludes.
-      </li>
-      <li>
-        <strong>Team allocation data:</strong>
-        Deleted after the course ends.
-      </li>
-      <li>
-        <strong>Developer profiles:</strong>
-        Deleted after the course ends.
-      </li>
-      <li>
-        <strong>Certificate data:</strong>
-        Retained as long as there is a legitimate interest of the student in re-downloading the certificate.
+        <strong>Course-related data (application, interview, team allocation, assessment, certificate, and developer profile data):</strong>
+        Deleted five years after the end of the last course in which the data subject participated on the platform.
       </li>
       <li>
         <strong>Server logs:</strong>
         Deleted after a maximum of 30 days.
       </li>
-      <li>
-        <strong>System metrics:</strong>
-        Aggregated system metrics (without personal reference) may be retained for longer periods for capacity planning and trend analysis purposes. Where metrics could have a personal reference (e.g. through association with IP addresses), they are deleted or anonymised after a maximum of 30 days.
-      </li>
-      <li>
-        <strong>Authentication data:</strong>
-        Session data expires automatically after a maximum of 24 hours. Account data in the identity provider is deleted when the account is no longer needed.
-      </li>
     </ul>
-    <p class="mt-2">
-      When a course is archived, associated data is marked as inactive. Final deletion takes place in accordance with the periods stated above.
-    </p>
   </section>
 
   <!-- Section 8: Local storage -->


### PR DESCRIPTION
## What is the change?

Updates [`clients/core/public/privacy.html`](clients/core/public/privacy.html) - the platform's privacy policy (German and English versions) with two categories of changes:

**1. Replace Art. 6(1)(f) GDPR (legitimate interest) with Art. 6(1)(e) GDPR / BayDSG / BayHIG (public task)**

All references to "legitimate interest" (berechtigtes Interesse / Art. 6 Abs. 1 lit. f DSGVO) have been removed and replaced with the correct legal basis for a public university: Art. 6(1)(e) GDPR in conjunction with Art. 4(1) BayDSG and Art. 2(1) BayHIG. This affects:

- Legal bases overview section (lit. f bullet point removed entirely from both DE and EN)
- Section 5.11 - Server logs and system metrics (legal basis line + system metrics paragraph)
- Section 6.1 - Gravatar integration
- Section 6.2 - GitHub API integration
- All corresponding English translation sections

**2. Simplify retention periods (Section 7, both DE and EN)**

The previously granular, per-category retention schedule has been consolidated to align with the officially registered Verarbeitungstätigkeit VT-1498 at TUM:

- All course-related personal data (application, interview, team allocation, assessment, certificate, developer profile) is now covered by a single rule: deleted 5 years after the end of the student's last course on the platform
- Server logs remain at 30 days (unchanged)
- Removed separate entries for: exam-relevant data (APSO/RaPO references), system metrics, and authentication data
- Removed the "archived course" data-marking paragraph

## Reason for the change

As a public university institution (TUM), PROMPT operates under Bavarian public law. Art. 6(1)(f) GDPR (legitimate interest) is only available to private entities - public authorities must use Art. 6(1)(e) GDPR (public task) as their legal basis. The previous privacy policy incorrectly cited lit. f for server logs, Gravatar, and GitHub.

The retention period consolidation aligns the public-facing privacy policy with the officially registered Verarbeitungstätigkeit VT-1498 filed with TUM's data protection office.

## How to Test

1. Check out this branch: `git checkout chore/privacy-statement-may-2026`
2. Open `clients/core/public/privacy.html` in a browser (or via the running dev environment)
3. Verify that the legal bases section (Section 4 in DE / Section 4 in EN) no longer lists Art. 6(1)(f) / Art. 6 Abs. 1 lit. f
4. Verify Section 5.11 cites `Art. 6 Abs. 1 lit. e DSGVO i.V.m. Art. 4 Abs. 1 BayDSG und Art. 2 Abs. 1 BayHIG` (DE) and the equivalent EN text
5. Verify Sections 6.1 and 6.2 use the same updated legal basis
6. Verify Section 7 (DE) / Section 7 (EN) shows a single consolidated retention rule for course-related data (5 years after last course) and server logs (30 days), with no separate entries for system metrics or authentication data

## Screenshots (if UI changes are included)

N/A - text-only changes to the privacy policy HTML file

## PR Checklist

- [x] Tested locally or on the dev environment
- [x] Code is clean, readable, and documented
- [ ] Tests added or updated (if needed)
- [ ] Screenshots attached for UI changes (if any)
- [ ] Documentation updated (if relevant)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated privacy policy with revised data processing legal bases and statutory references for Bavarian compliance
  * Simplified data retention schedule: server logs deleted after 30 days maximum; course-related data retained for 5 years after final course participation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/prompt-edu/prompt/pull/1634)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->